### PR TITLE
fix: verificacion de email a prueba de escaneres de correo (Safe Links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Next.js](https://img.shields.io/badge/Next.js-15-black?logo=next.js)](https://nextjs.org/)
 [![React](https://img.shields.io/badge/React-19-blue?logo=react)](https://reactjs.org/)
-[![Firebase](https://img.shields.io/badge/Firebase-Firestore-orange?logo=firebase)](https://firebase.google.com/)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-Prisma-blue?logo=postgresql)](https://www.prisma.io/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 ---
@@ -17,7 +17,7 @@
 -  **Google Calendar Integration** - Automatic sync with tutor schedules
 -  **Session Management** - Book, reschedule, and track tutoring sessions
 -  **Payment Integration** - Wompi payment processing
-- 🔐 **Firebase Auth** - Secure authentication for students and tutors
+- 🔐 **Custom JWT Auth** - bcrypt + jsonwebtoken, email verification gate
 - 📊 **Analytics** - Track sessions, earnings, and student progress
 
 ---
@@ -40,7 +40,7 @@ npm run dev
 
 Visit `http://localhost:3000` to see the app running.
 
-** For complete setup guide, see [AGENT.md](AGENT.md)**
+** For architecture, conventions and API reference, see [documentation/CLAUDE.md](documentation/CLAUDE.md)**
 
 ---
 
@@ -63,7 +63,7 @@ src/
 
 **Data Flow:**
 ```
-Component → Service → API Route → Business Logic → Repository → Firestore
+Component → Service → API Route → Business Logic → Repository → Prisma → PostgreSQL
 ```
 
 **Benefits:**
@@ -145,9 +145,9 @@ background: rgba(0, 107, 179, 0.12);
 | **Framework** | Next.js 15 (App Router) |
 | **Frontend** | React 19, Tailwind CSS, shadcn/ui |
 | **Backend** | Next.js API Routes |
-| **Database** | Firebase Firestore |
-| **Auth** | Firebase Authentication |
-| **APIs** | Google Calendar, Google Drive |
+| **Database** | PostgreSQL + Prisma ORM |
+| **Auth** | Custom JWT (bcrypt + jsonwebtoken) |
+| **APIs** | Google Calendar, Google Drive, Wompi, Brevo, AWS S3 |
 | **Validation** | Zod |
 | **Testing** | Jest + Testing Library |
 
@@ -155,11 +155,10 @@ background: rgba(0, 107, 179, 0.12);
 
 ##  Documentation
 
-- **[AGENT.md](AGENT.md)** - Complete guide for developers and AI agents
-- **[API_ENDPOINTS.md](API_ENDPOINTS.md)** - API reference
-- **[MONOLITH_ARCHITECTURE.md](MONOLITH_ARCHITECTURE.md)** - Architecture details
-- **[FIRESTORE_SETUP.md](FIRESTORE_SETUP.md)** - Database setup
-- **[PROJECT_ERRORS_ANALYSIS.md](PROJECT_ERRORS_ANALYSIS.md)** - Known issues
+- **[documentation/CLAUDE.md](documentation/CLAUDE.md)** - Architecture, conventions, DB schema, full API reference
+- **[documentation/ADMIN_DASHBOARD_PLAN.md](documentation/ADMIN_DASHBOARD_PLAN.md)** - Admin panel design & execution status
+- **[documentation/testing/STUDENT_BOOKING_TESTS.md](documentation/testing/STUDENT_BOOKING_TESTS.md)** - Student booking test suite
+- **[documentation/flujo_materias](documentation/flujo_materias)** - Tutor lifecycle & course approval flow (business spec)
 
 ---
 
@@ -183,7 +182,7 @@ docker run -p 3000:3000 calico-monitorias
 2. Login with `calico.tutorias@gmail.com`
 3. Grant permissions
 
-See [AGENT.md](AGENT.md#google-oauth-setup-critical---one-time-setup) for details.
+See the External Services / Google Calendar section in [documentation/CLAUDE.md](documentation/CLAUDE.md) for details.
 
 ---
 
@@ -191,9 +190,9 @@ See [AGENT.md](AGENT.md#google-oauth-setup-critical---one-time-setup) for detail
 
 ### For Developers
 
-1. Read [AGENT.md](AGENT.md) first
+1. Read [documentation/CLAUDE.md](documentation/CLAUDE.md) first
 2. Follow the minimalist coding principles
-3. Always add `limit` to Firestore queries
+3. Filter on the server with Prisma `where` (never fetch all rows then filter in JS)
 4. Validate inputs with Zod
 5. Test locally before pushing
 6. **Visual** — Never hardcode colors; always use a CSS token from `design-tokens.css` (see [Sistema de Diseño Visual](#-sistema-de-diseño-visual))
@@ -202,20 +201,20 @@ See [AGENT.md](AGENT.md#google-oauth-setup-critical---one-time-setup) for detail
 
 This project has specific guidelines for AI coding assistants:
 - **Be minimalist** - Write the smallest possible change
-- **Be cost-conscious** - Never pull full collections
+- **Filter on the server** - Never fetch all rows then filter in JS; use Prisma `where`
 - **Follow patterns** - API → Service → Repository
 - **CSS tokens only** - Read `src/app/styles/design-tokens.css` before writing any color. The Cursor rule `.cursor/rules/css-design-system.mdc` will auto-load guidance for all `.css` files
-- **Check [AGENT.md](AGENT.md#for-ai-coding-assistants)** for complete guidelines
+- **Check [documentation/CLAUDE.md](documentation/CLAUDE.md)** for complete guidelines
 
 ---
 
 ##  Known Issues
 
 - **DB inconsistencies** - Mixed use of `tutorId` vs `tutorEmail` (prefer IDs in new code)
-- **Over-requesting** - Project hit Firebase limits; always use `limit` in queries
 - **Next.js 15** - Must `await params` in dynamic routes
+- **Identity from JWT** - Extract `auth.sub` after `authenticateRequest`; never trust IDs from the request body/URL (IDOR)
 
-See [AGENT.md](AGENT.md#known-issues--pitfalls) for details and fixes.
+See [documentation/CLAUDE.md](documentation/CLAUDE.md) for details and conventions.
 
 ---
 

--- a/documentation/CLAUDE.md
+++ b/documentation/CLAUDE.md
@@ -71,11 +71,12 @@ React Component → Frontend Service (src/app/services/core/) → fetch('/api/..
 
 ### Auth Flow
 
-1. **Register** → `POST /api/auth/register` → hash password → create user → send verification email via Brevo → return JWT
-2. **Login** → `POST /api/auth/login` → bcrypt compare → return JWT
-3. **Client** → store JWT in `localStorage` as `calico_auth_token`
-4. **Protected routes** → `authenticateRequest(request)` in `src/lib/auth/middleware.js` extracts and verifies Bearer token
-5. **App mount** → `GET /api/auth/me` validates token and loads user profile into `SecureAuthContext`
+1. **Register** → `POST /api/auth/register` → hash password → create user → send verification email via Brevo (no JWT issued — email must be verified first)
+2. **Verify email** → user clicks link → `/auth/confirm-email` → explicit click → `POST /api/auth/verify-email` marks verified
+3. **Login** → `POST /api/auth/login` → bcrypt compare → rejects if `!isEmailVerified` → return JWT
+4. **Client** → store JWT in `localStorage` as `calico_auth_token`
+5. **Protected routes** → `authenticateRequest(request)` in `src/lib/auth/middleware.js` extracts and verifies Bearer token
+6. **App mount** → `GET /api/auth/me` validates token and loads user profile into `SecureAuthContext`
 
 JWT payload: `{ sub: userId, email, isTutorRequested, isTutorApproved, iat, exp }`. Expiry set via `JWT_EXPIRATION` env var (default `7d`).
 
@@ -91,7 +92,9 @@ JWT payload: `{ sub: userId, email, isTutorRequested, isTutorApproved, iat, exp 
 |-------|---------|--------|
 | `authenticateRequest(request)` | Verify any logged-in user | `Authorization: Bearer <jwt>` |
 | `requireTutor(request)` | Authenticated AND `isTutorApproved` | `Authorization: Bearer <jwt>` |
-| `requireAdmin(request)` | Compares `x-admin-secret` against `ADMIN_SECRET` env var (no JWT) | `x-admin-secret: <secret>` |
+| `requireAdminUser(request)` | Authenticated AND DB `role = 'ADMIN'` (role read fresh from DB, not JWT) + `isActive` + 30 req/min limit. **Use this for human admins.** | `Authorization: Bearer <jwt>` |
+| `requireAdminSecret(request)` | Compares `x-admin-secret` against `ADMIN_SECRET` env var (no JWT). Service/cron only. | `x-admin-secret: <secret>` |
+| `requireAdmin(request)` | **@deprecated** alias of `requireAdminSecret` | `x-admin-secret: <secret>` |
 
 All three return `NextResponse` on failure — early-return when `result instanceof NextResponse`.
 
@@ -105,8 +108,8 @@ Schema: `prisma/schema.prisma`. Client output: `src/generated/prisma/`.
 
 | Table | PK type | Description |
 |-------|---------|-------------|
-| `users` | `Int` (autoincrement) | Core user — auth + profile |
-| `tutor_profiles` | `Int` (userId) | Tutor-specific data (1:1 with user) |
+| `users` | `String` (UUID) | Core user — auth + profile |
+| `tutor_profiles` | `String` (userId, UUID) | Tutor-specific data (1:1 with user) |
 | `courses` | `UUID` | Academic courses with complexity + base price |
 | `topics` | `UUID` | Course subtopics |
 | `tutor_courses` | composite (tutorId, courseId) | Many-to-many tutor ↔ course with custom price |
@@ -119,17 +122,27 @@ Schema: `prisma/schema.prisma`. Client output: `src/generated/prisma/`.
 ### Enums
 
 ```
-MajorEnum:         ISIS | MATE | FISI | ADMI | ICIV | IMEC
-ComplexityEnum:    Introductory | Foundational | Challenging
-SessionTypeEnum:   Individual | Group
-SessionStatusEnum: Pending | Accepted | Rejected | Completed | Canceled
-LocationTypeEnum:  Virtual | Custom
+Role:                       STUDENT | ADMIN
+AuthProviderEnum:           Local | Google
+ComplexityEnum:             Introductory | Foundational | Challenging
+SessionTypeEnum:            Individual | Group
+SessionStatusEnum:          Pending | Accepted | Rejected | Completed | Canceled
+LocationTypeEnum:           Virtual | Custom
+TutorApplicationStatusEnum: Pending | Approved | Rejected
+TutorCourseStatusEnum:      Pending | Approved | Rejected
+PaymentStatusEnum:          pending | paid | failed
+TutorPayoutStatusEnum:      pending | paid
+ReviewStatusEnum:           pending | done
 ```
+
+> Majors/careers are **no longer an enum** — they are the `Department` + `Career`
+> tables (UUID PKs). `User.careerId` is a UUID FK. The legacy `MajorEnum`
+> (ISIS/MATE/…) was removed in the Firebase → PostgreSQL migration.
 
 ### Key Fields
 
 - `User.isTutorRequested` / `isTutorApproved` — role gating
-- `User.isEmailVerified` — required before login is useful
+- `User.isEmailVerified` — hard login gate: `/api/auth/login` returns `EMAIL_NOT_VERIFIED` (403) until true; no JWT is issued anywhere before verification
 - `Schedule.autoAcceptSession` — auto-accept incoming session requests
 - `Schedule.bufferTime` — minutes between sessions (default 15)
 - `Availability.dayOfWeek` — 0 (Sunday) to 6 (Saturday)
@@ -145,10 +158,11 @@ All protected routes require `Authorization: Bearer <token>`.
 
 | Route | Method | Auth | Description |
 |-------|--------|------|-------------|
-| `/api/auth/register` | POST | — | Register, send verification email, return JWT |
-| `/api/auth/login` | POST | — | Email + password → JWT |
+| `/api/auth/register` | POST | — | Register + send verification email. **No JWT** — email must be verified, then login |
+| `/api/auth/login` | POST | — | Email + password → JWT (rejected if `!isEmailVerified`) |
 | `/api/auth/me` | GET | ✓ | Validate token, return user profile |
-| `/api/auth/verify-email` | GET | — | Validate token → redirect to `/auth/email-verified?status=` |
+| `/api/auth/verify-email` | POST | — | Validate token → mark verified (explicit user click only) |
+| `/api/auth/verify-email` | GET | — | No-op redirect to `/auth/confirm-email?token=` (scanner-safe; legacy emails) |
 | `/api/auth/resend-verification` | POST | — | Resend verification email |
 | `/api/auth/forgot-password` | POST | — | Send password reset link via Brevo |
 | `/api/auth/reset-password` | POST | — | Validate token → set new password |
@@ -233,7 +247,9 @@ Backed by `wompi.service.js` + `payment.repository.js`. Webhook integrity is enf
 
 Backed by `session-attachment.service.js` + `session-attachment.repository.js`.
 
-### Admin (`/api/admin/`) — `x-admin-secret` header required
+### Admin (`/api/admin/`)
+
+Auth is **mixed**: most admin routes (`audit`, `metrics/*`, `payouts/*`, tutor management) use `requireAdminUser` (Bearer JWT + DB `role = 'ADMIN'`). Legacy `course-prices*` and `tutor-courses*` still use `requireAdmin`/`x-admin-secret`.
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -254,11 +270,11 @@ Backed by `session-attachment.service.js` + `session-attachment.repository.js`.
 | `/api/schedules/me` | GET/PUT | My schedule preferences |
 | `/api/sessions/stats` | GET | Aggregated session stats |
 | `/api/availabilities/sync-from-calendar` | POST | Pull availability from Google Calendar |
-| `/api/auth/google` | GET | Google OAuth entry |
+| `/api/auth/google` | POST | Verify Google ID token → create/link user → JWT |
 | `/api/courses` | GET | All courses |
 | `/api/courses/[id]` | GET | Single course |
-| `/api/majors` | GET | Available majors (enum values) |
-| `/api/majors/[id]` | GET | Single major |
+| `/api/majors` | GET | All careers + their department (from DB, not an enum) |
+| `/api/majors/[id]` | GET | Single career |
 
 ### Google Calendar (`/api/calendar/`, `/api/calico-calendar/`) — maintained unchanged
 
@@ -271,10 +287,18 @@ REST API v3 (`https://api.sendinblue.com/v3/smtp/email`). Service: `src/lib/serv
 
 Env vars: `BREVO_API_KEY`, `BREVO_SENDER_EMAIL`, `BREVO_SENDER_NAME`
 
-Template IDs (configure in Brevo dashboard):
-- `13` — Email verification
-- `14` — Password reset link
-- `15` — Password changed confirmation
+Template IDs — single source of truth is `TEMPLATE_IDS` in `email.service.js`:
+- `2` — Email verification
+- `3` — Password changed confirmation
+- `4` — Password reset link
+- `5` — Tutor application (admin notification)
+- `7` — Session confirmed
+- `8` — New session request / session cancelled (recipient)
+- `9` — Session cancelled (admin)
+- `10` — Course request (admin notification)
+- `11` — Tutor application approved
+- `12` — Tutor application rejected
+- `13` — Tutor suspended
 
 ### AWS S3 (File Storage)
 Service: `src/lib/s3.js`. Presigned URLs for direct browser → S3 uploads.
@@ -424,7 +448,7 @@ For toggle groups (e.g., period filters), use `<Button>` with conditional `varia
 
 ## Related Documentation
 
-- [AGENT.md](AGENT.md) — Comprehensive developer and AI assistant guide
-- [API_ENDPOINTS.md](API_ENDPOINTS.md) — API reference
-- [MONOLITH_ARCHITECTURE.md](MONOLITH_ARCHITECTURE.md) — Architecture details
-- [MIGRATION_PLAN.md](MIGRATION_PLAN.md) — Firebase → PostgreSQL migration notes
+- [ADMIN_DASHBOARD_PLAN.md](ADMIN_DASHBOARD_PLAN.md) — Admin panel design & execution status
+- [testing/STUDENT_BOOKING_TESTS.md](testing/STUDENT_BOOKING_TESTS.md) — Student booking test suite
+- [flujo_materias](flujo_materias) — Tutor lifecycle & course approval flow (business spec)
+- [../README.md](../README.md) — Project overview & quick start

--- a/src/app/api/auth/register/route.js
+++ b/src/app/api/auth/register/route.js
@@ -7,7 +7,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import bcrypt from 'bcrypt';
-import { signToken } from '@/lib/auth/jwt';
 import * as userRepository from '@/lib/repositories/user.repository';
 import * as userService from '@/lib/services/user.service';
 import { sendVerificationEmail } from '@/lib/services/email.service';
@@ -77,12 +76,12 @@ export async function POST(request) {
       console.error('[Register] Failed to send verification email:', err);
     });
 
-    // 5. Sign JWT
-    const token = signToken(user);
-
+    // 5. Do NOT issue a JWT here. A token is only granted via POST
+    // /api/auth/login, which rejects accounts whose email is not yet
+    // verified. This guarantees email verification is a hard gate for
+    // obtaining any authenticated session — not just a frontend convention.
     return NextResponse.json({
       success: true,
-      token,
       user,
     }, { status: 201 });
   } catch (error) {

--- a/src/app/api/auth/verify-email/route.js
+++ b/src/app/api/auth/verify-email/route.js
@@ -1,6 +1,16 @@
 /**
- * GET /api/auth/verify-email?token=XXX
- * Validates the email verification token and redirects to the frontend.
+ * Email verification endpoint.
+ *
+ * POST /api/auth/verify-email   { token }  → validates the token and marks the
+ *   user as verified. This is the ONLY state-mutating path and is triggered by
+ *   an explicit user click on the frontend confirmation page.
+ *
+ * GET /api/auth/verify-email?token=XXX → does NOT mutate state. It only
+ *   redirects to the frontend confirmation page carrying the token. Kept for
+ *   backward compatibility with verification emails sent before this change.
+ *   Crucially, email security scanners (Microsoft Defender Safe Links, link
+ *   previews, antivirus) prefetch links with GET — routing that GET through a
+ *   harmless redirect prevents them from auto-verifying accounts.
  */
 
 export const dynamic = 'force-dynamic';
@@ -9,26 +19,40 @@ import { NextResponse } from 'next/server';
 import * as userService from '@/lib/services/user.service';
 
 export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const token = searchParams.get('token');
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || new URL(request.url).origin;
+
+  const url = new URL('/auth/confirm-email', baseUrl);
+  if (token && typeof token === 'string' && token.length <= 128) {
+    url.searchParams.set('token', token);
+  }
+  return NextResponse.redirect(url.toString());
+}
+
+export async function POST(request) {
   try {
-    const { searchParams } = new URL(request.url);
-    const token = searchParams.get('token');
+    let token;
+    try {
+      ({ token } = await request.json());
+    } catch {
+      return NextResponse.json({ success: false, status: 'error' }, { status: 400 });
+    }
 
     if (!token || typeof token !== 'string' || token.length > 128) {
-      return redirectToStatus('error', request);
+      return NextResponse.json({ success: false, status: 'error' }, { status: 400 });
     }
 
     const { status } = await userService.verifyEmailToken(token);
 
-    return redirectToStatus(status, request);
+    // 'success' | 'already' → 200; 'expired' | 'invalid' → 400
+    const ok = status === 'success' || status === 'already';
+    return NextResponse.json(
+      { success: ok, status },
+      { status: ok ? 200 : 400 },
+    );
   } catch (error) {
-    console.error('Error in GET /api/auth/verify-email:', error);
-    return redirectToStatus('error', request);
+    console.error('Error in POST /api/auth/verify-email:', error);
+    return NextResponse.json({ success: false, status: 'error' }, { status: 500 });
   }
-}
-
-function redirectToStatus(status, request) {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || new URL(request.url).origin;
-  const url = new URL('/auth/email-verified', baseUrl);
-  url.searchParams.set('status', status);
-  return NextResponse.redirect(url.toString());
 }

--- a/src/app/auth/confirm-email/page.jsx
+++ b/src/app/auth/confirm-email/page.jsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Image from 'next/image';
+import { useI18n } from '../../../lib/i18n';
+import { AuthService } from '../../services/utils/AuthService';
+import routes from '../../../routes';
+import CalicoLogo from '../../../../public/CalicoLogo.png';
+import { BrandMascot } from '../../components/BrandMascot/BrandMascot';
+import { AlertCircle } from 'lucide-react';
+import '../login/Login.css';
+
+export default function ConfirmEmailPage() {
+  return (
+    <Suspense fallback={<div className="login-page PrimaryBackground" />}>
+      <ConfirmEmailContent />
+    </Suspense>
+  );
+}
+
+function ConfirmEmailContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { t } = useI18n();
+
+  const token = searchParams.get('token') || '';
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleConfirm = async () => {
+    if (submitting || !token) return;
+    setSubmitting(true);
+    // 'invalid' from the API maps to the 'error' state on the result page,
+    // which renders the "request a new link" message.
+    const { status } = await AuthService.verifyEmail(token);
+    const mapped = status === 'invalid' ? 'error' : status;
+    router.replace(`${routes.EMAIL_VERIFIED}?status=${encodeURIComponent(mapped)}`);
+  };
+
+  return (
+    <main className="login-page PrimaryBackground">
+      <section className="login-wrapper">
+        <div className="login-card">
+          <div className="flex flex-col justify-center items-center">
+            <Image src={CalicoLogo} alt="Calico" className="logoImg w-28 md:w-36" priority />
+            <BrandMascot className="mt-3" alt="" />
+            <h2 className="login-title mt-4">{t('auth.confirmEmail.title')}</h2>
+          </div>
+
+          {token ? (
+            <>
+              <p className="text-gray-600 mt-4 text-sm">
+                {t('auth.confirmEmail.description')}
+              </p>
+
+              <button
+                onClick={handleConfirm}
+                disabled={submitting}
+                className="login-btn w-full mt-6 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {submitting
+                  ? t('auth.confirmEmail.confirming')
+                  : t('auth.confirmEmail.confirmButton')}
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="mt-4 flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg p-3 text-left">
+                <AlertCircle className="w-4 h-4 text-amber-600 flex-shrink-0 mt-0.5" />
+                <p className="text-amber-800 text-xs leading-relaxed">
+                  {t('auth.confirmEmail.missingToken')}
+                </p>
+              </div>
+
+              <button
+                onClick={() => router.push(routes.LOGIN)}
+                className="login-btn w-full mt-6"
+              >
+                {t('auth.emailVerified.goLogin')}
+              </button>
+            </>
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/services/utils/AuthService.js
+++ b/src/app/services/utils/AuthService.js
@@ -181,6 +181,25 @@ export const AuthService = {
   // Email verification
   // ---------------------------------------------------------------------------
 
+  /**
+   * Confirm an email verification token (explicit user action → POST).
+   * Returns { status } where status is one of:
+   * 'success' | 'already' | 'expired' | 'invalid' | 'error'.
+   */
+  verifyEmail: async (token) => {
+    try {
+      const response = await fetch(`${API_URL}/auth/verify-email`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      });
+      const data = await response.json().catch(() => ({}));
+      return { status: data.status || 'error' };
+    } catch {
+      return { status: 'error' };
+    }
+  },
+
   checkVerification: async (email) => {
     const response = await fetch(
       `${API_URL}/auth/check-verification?email=${encodeURIComponent(email)}`,

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1417,6 +1417,13 @@
       "resendError": "Failed to resend email. Please try again.",
       "backToLogin": "Back to login"
     },
+    "confirmEmail": {
+      "title": "Confirm your email",
+      "description": "Click the button to confirm your email address and activate your account.",
+      "confirmButton": "Confirm my email",
+      "confirming": "Confirming...",
+      "missingToken": "The link is incomplete or missing its verification token. Request a new one from the login page."
+    },
     "emailVerified": {
       "successTitle": "Email verified!",
       "successMessage": "Your email has been verified successfully. You can now access all Calico features.",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -1423,6 +1423,13 @@
         "resendError": "Error al reenviar el correo. Intenta de nuevo.",
         "backToLogin": "Volver al inicio de sesión"
       },
+      "confirmEmail": {
+        "title": "Confirma tu correo",
+        "description": "Haz clic en el botón para confirmar tu dirección de correo y activar tu cuenta.",
+        "confirmButton": "Confirmar mi correo",
+        "confirming": "Confirmando...",
+        "missingToken": "El enlace está incompleto o le falta el token de verificación. Solicita uno nuevo desde el inicio de sesión."
+      },
       "emailVerified": {
         "successTitle": "¡Correo verificado!",
         "successMessage": "Tu correo electrónico ha sido verificado exitosamente. Ya puedes acceder a todas las funciones de Calico.",

--- a/src/lib/services/email.service.js
+++ b/src/lib/services/email.service.js
@@ -104,7 +104,12 @@ async function sendBrevoEmail({ to, templateId, params }) {
  */
 export async function sendVerificationEmail(email, name, verificationToken) {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  const verificationLink = `${baseUrl}/api/auth/verify-email?token=${encodeURIComponent(verificationToken)}`;
+  // Point to the frontend confirmation page (NOT the API directly). The page
+  // requires an explicit user click that issues a POST to verify. Email
+  // security scanners (e.g. Microsoft Defender Safe Links) only perform GET
+  // prefetches and do not click buttons, so they no longer auto-verify
+  // accounts before the user opens the email.
+  const verificationLink = `${baseUrl}/auth/confirm-email?token=${encodeURIComponent(verificationToken)}`;
 
   return sendBrevoEmail({
     to: [{ email, name }],

--- a/src/routes.js
+++ b/src/routes.js
@@ -18,6 +18,7 @@ const routes = {
     LOGIN:"/auth/login",
     REGISTER:"/auth/register",
     VERIFY_EMAIL: "/auth/verify-email",
+    CONFIRM_EMAIL: "/auth/confirm-email",
     EMAIL_VERIFIED: "/auth/email-verified",
     FORGOT_PASSWORD: "/auth/forgot-password",
     RESET_PASSWORD: "/auth/reset-password",


### PR DESCRIPTION
Diagnóstico
GET /api/auth/verify-email?token=XXX era un endpoint GET que mutaba la BBDD (isEmailVerified = true). Tu correo institucional (Microsoft 365 con Defender / Safe Links) hace un GET automático a todos los enlaces para escanearlos antes de que abras el correo. Ese GET del bot consumió el token y verificó tu cuenta solo. El polling de /auth/verify-email lo detectó y te mandó a HOME. No era aleatorio: le pasaba a todo correo institucional Microsoft (y a previews de WhatsApp/Slack/antivirus).

Cambios
[email.service.js](vscode-webview://1ggr5g1sqocveklhhtoknj03ifka7drubb9fgp92so6bj7cmjsha/src/lib/services/email.service.js#L106-L112) — el enlace ahora apunta al frontend (/auth/confirm-email?token=), no a la API.
[verify-email/route.js](vscode-webview://1ggr5g1sqocveklhhtoknj03ifka7drubb9fgp92so6bj7cmjsha/src/app/api/auth/verify-email/route.js) — el GET ya no muta: solo redirige al frontend (a prueba de bots y compatible con correos viejos en tránsito). La verificación real se hace en un nuevo POST que solo se dispara con el clic explícito del usuario.
[confirm-email/page.jsx](vscode-webview://1ggr5g1sqocveklhhtoknj03ifka7drubb9fgp92so6bj7cmjsha/src/app/auth/confirm-email/page.jsx) (nueva) — muestra el botón "Confirmar mi correo"; solo al clic se hace el POST. Los escáneres Safe Links hacen GET y no clican botones ni corren JS, así que ya no pueden auto-verificar.
[AuthService.js](vscode-webview://1ggr5g1sqocveklhhtoknj03ifka7drubb9fgp92so6bj7cmjsha/src/app/services/utils/AuthService.js) — nuevo método verifyEmail(token) (POST).
[routes.js](vscode-webview://1ggr5g1sqocveklhhtoknj03ifka7drubb9fgp92so6bj7cmjsha/src/routes.js#L21), i18n (es/en) y documentation/CLAUDE.md actualizados.
El flujo de resultado (/auth/email-verified?status=success|already|expired|error) y los correos ya enviados antes del deploy siguen funcionando gracias a la redirección del GET.