### PR TITLE
feat: calificación recíproca tutor→estudiante + endurecimiento de seguridad

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,8 +3,34 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Baseline security headers applied to every response. Intentionally does NOT
+// include a strict Content-Security-Policy: enforcing CSP on a Next.js app that
+// also loads the Wompi widget + Google OAuth needs a dedicated test pass (inline
+// hydration scripts, styled-jsx, third-party origins) and is tracked separately.
+// X-Frame-Options already blocks the main clickjacking vector here.
+const securityHeaders = [
+  // Force HTTPS for 2 years incl. subdomains. Browsers ignore this on localhost.
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  // Stop MIME-type sniffing (defends against content-type confusion attacks).
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  // Disallow the site being framed by other origins → clickjacking protection.
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  // Don't leak full URLs (incl. tokens in query strings) to third parties.
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  // Drop powerful features the app never uses in its own origin.
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()' },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ];
+  },
   async redirects() {
     return [
       {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,12 +140,24 @@ model User {
   resetTokenExpiry        DateTime? @map("reset_token_expiry")
   otpCode           String?   @map("otp_code")
   otpCodeExpiry     DateTime? @map("otp_code_expiry")
+  // Failed OTP verification attempts for the current code. Reset to 0 when a
+  // fresh OTP is issued; once it hits the cap the code is invalidated to stop
+  // brute-forcing the 6-digit OTP (server-side, survives across instances).
+  otpAttempts       Int       @default(0) @map("otp_attempts")
 
   // Última vez que el usuario estuvo en la app ("last seen"). Se usa para
   // métricas de engagement (usuarios activos en la última semana). Como la
   // sesión JWT persiste, NO basta con el login: se refresca también en el
   // heartbeat /api/auth/me (con throttle). Best-effort / fire-and-forget.
   lastSeenAt DateTime? @map("last_seen_at")
+
+  // Calificación como ESTUDIANTE (tutores → estudiante, estilo Uber).
+  // Agregado denormalizado de student_reviews con status 'done' — mismo
+  // patrón que TutorProfile.review/numReview. PRIVADA: visible solo para
+  // tutores con una sesión vinculada a este estudiante, para admins y para
+  // el propio estudiante (solo el número, nunca los comentarios).
+  studentRating      Decimal @default(0) @db.Decimal(3, 2) @map("student_rating")
+  studentRatingCount Int     @default(0) @map("student_rating_count")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt     @map("updated_at")
@@ -159,6 +171,8 @@ model User {
   participations SessionParticipant[]
   reviewsWritten Review[]               @relation("ReviewsWritten")
   reviewsReceived Review[]              @relation("ReviewsReceived")
+  studentReviewsWritten  StudentReview[] @relation("StudentReviewsWritten")
+  studentReviewsReceived StudentReview[] @relation("StudentReviewsReceived")
   paymentsAsStudent Payment[]           @relation("PaymentsStudent")
   paymentsAsTutor Payment[]             @relation("PaymentsTutor")
   tutorApplications TutorApplication[]
@@ -333,6 +347,7 @@ model Session {
   participants  SessionParticipant[]
   payments      Payment[]
   reviews       Review[]
+  studentReviews StudentReview[]
   notifications Notification[]
   attachments   SessionAttachment[]
 
@@ -394,6 +409,35 @@ model Review {
   @@unique([sessionId, studentId, tutorId])
   @@index([tutorId, courseId, status])
   @@map("reviews")
+}
+
+// ─── STUDENT REVIEWS (tutor → estudiante, privadas) ───────────────────
+// Calificación recíproca estilo Uber: el tutor califica al estudiante tras
+// completar la sesión. NO es pública: el agregado (User.studentRating) lo ven
+// los tutores con una sesión vinculada al estudiante y el propio estudiante
+// (solo el número); el comment individual lo ve únicamente el admin
+// (moderación / suspensión por ratings bajos). Tabla separada de Review a
+// propósito — la visibilidad opuesta (pública vs privada) se mantiene
+// estructural en vez de depender de filtros por dirección en cada query.
+
+model StudentReview {
+  id        String           @id @default(uuid())
+  sessionId String           @map("session_id")
+  tutorId   String           @map("tutor_id")   // quien califica (reviewer)
+  studentId String           @map("student_id") // quien recibe (reviewee)
+  rating    Int?
+  status    ReviewStatusEnum @default(pending)
+  comment   String?
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt     @map("updated_at")
+
+  session Session @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  tutor   User    @relation("StudentReviewsWritten", fields: [tutorId], references: [id], onDelete: Cascade)
+  student User    @relation("StudentReviewsReceived", fields: [studentId], references: [id], onDelete: Cascade)
+
+  @@unique([sessionId, tutorId, studentId])
+  @@index([studentId, status])
+  @@map("student_reviews")
 }
 
 // ─── PAYMENTS ─────────────────────────────────────────────────────────

--- a/src/__tests__/api/student-reviews.api.test.js
+++ b/src/__tests__/api/student-reviews.api.test.js
@@ -1,0 +1,414 @@
+/**
+ * @jest-environment node
+ *
+ * Integration tests — tutor→student reciprocal reviews at the HTTP boundary.
+ * Exercises route handler → service → repository with Prisma mocked at the
+ * singleton level (same pattern as user-reviews.api.test.js).
+ *
+ * Routes covered:
+ *   POST /api/sessions/:id/student-reviews — create/edit (tutor only)
+ *   GET  /api/sessions/:id/student-reviews — caller's own reviews only
+ *   GET  /api/users/me/student-rating      — own aggregate (number only)
+ *   GET  /api/sessions & /api/sessions/:id — PRIVACY: rating attached only
+ *                                            to tutor payloads
+ */
+
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    user: { findMany: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
+    session: { findMany: jest.fn(), findUnique: jest.fn() },
+    studentReview: { findMany: jest.fn(), upsert: jest.fn() },
+    $transaction: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/auth/guards', () => ({
+  requireTutor: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/middleware', () => ({
+  authenticateRequest: jest.fn(),
+  tryAuthenticateRequest: jest.fn(),
+}));
+
+const { NextResponse } = require('next/server');
+const prisma = require('@/lib/prisma').default;
+const { requireTutor } = require('@/lib/auth/guards');
+const { authenticateRequest } = require('@/lib/auth/middleware');
+
+const TUTOR_AUTH = { sub: 'tutor-1', email: 'tutor@test.co', isTutorApproved: true };
+const STUDENT_AUTH = { sub: 'student-1', email: 'stu@test.co', isTutorApproved: false };
+
+function makeDbSession(overrides = {}) {
+  const past = new Date(Date.now() - 3600_000);
+  return {
+    id: 'session-1',
+    tutorId: 'tutor-1',
+    courseId: 'course-1',
+    status: 'Completed',
+    startTimestamp: new Date(past.getTime() - 3600_000),
+    endTimestamp: past,
+    participants: [
+      { sessionId: 'session-1', studentId: 'student-1', student: { id: 'student-1', name: 'Ana', email: 'stu@test.co', profilePictureUrl: null } },
+    ],
+    payments: [],
+    reviews: [],
+    course: { id: 'course-1', name: 'Cálculo I' },
+    tutor: { id: 'tutor-1', name: 'Tutor', email: 'tutor@test.co', profilePictureUrl: null },
+    ...overrides,
+  };
+}
+
+function buildPost(url, body) {
+  return new Request(url, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // $transaction: run the callback against the same prisma mock as tx
+  prisma.$transaction.mockImplementation(async (cb) => cb(prisma));
+  prisma.studentReview.findMany.mockResolvedValue([]);
+  prisma.user.update.mockResolvedValue({ id: 'student-1', studentRating: 4, studentRatingCount: 1 });
+});
+
+// ─── POST /api/sessions/:id/student-reviews ─────────────────────────
+
+describe('POST /api/sessions/:id/student-reviews', () => {
+  let POST;
+  beforeAll(() => {
+    POST = require('@/app/api/sessions/[id]/student-reviews/route').POST;
+  });
+
+  it('rejects non-tutors via the requireTutor guard', async () => {
+    requireTutor.mockReturnValue(
+      NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 }),
+    );
+
+    const res = await POST(
+      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 5 }),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+
+    expect(res.status).toBe(403);
+    expect(prisma.studentReview.upsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on out-of-range rating (zod)', async () => {
+    requireTutor.mockReturnValue(TUTOR_AUTH);
+
+    const res = await POST(
+      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 6 }),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+
+    expect(res.status).toBe(400);
+    expect(prisma.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('creates the review (201), upserting as done and recomputing the aggregate', async () => {
+    requireTutor.mockReturnValue(TUTOR_AUTH);
+    prisma.session.findUnique.mockResolvedValue(makeDbSession());
+    prisma.studentReview.upsert.mockResolvedValue({
+      id: 'sr-1', sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1',
+      rating: 5, status: 'done', comment: null,
+    });
+
+    const res = await POST(
+      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 5 }),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.review.status).toBe('done');
+
+    const upsertArgs = prisma.studentReview.upsert.mock.calls[0][0];
+    expect(upsertArgs.where).toEqual({
+      sessionId_tutorId_studentId: { sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1' },
+    });
+    expect(upsertArgs.create).toMatchObject({ rating: 5, status: 'done' });
+    // Aggregate recomputed on the user row
+    expect(prisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'student-1' } }),
+    );
+  });
+
+  it('returns 200 + updated=true when editing an existing done review', async () => {
+    requireTutor.mockReturnValue(TUTOR_AUTH);
+    prisma.session.findUnique.mockResolvedValue(makeDbSession());
+    prisma.studentReview.findMany.mockResolvedValue([
+      { id: 'sr-1', sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1', status: 'done', rating: 3 },
+    ]);
+    prisma.studentReview.upsert.mockResolvedValue({
+      id: 'sr-1', sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1',
+      rating: 5, status: 'done', comment: null,
+    });
+
+    const res = await POST(
+      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 5 }),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.updated).toBe(true);
+  });
+
+  it('returns 403 NOT_SESSION_TUTOR when the caller is a tutor of another session', async () => {
+    requireTutor.mockReturnValue({ ...TUTOR_AUTH, sub: 'otro-tutor' });
+    prisma.session.findUnique.mockResolvedValue(makeDbSession());
+
+    const res = await POST(
+      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 5 }),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.code).toBe('NOT_SESSION_TUTOR');
+    expect(prisma.studentReview.upsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 INVALID_STUDENT when the reviewee is not a participant', async () => {
+    requireTutor.mockReturnValue(TUTOR_AUTH);
+    prisma.session.findUnique.mockResolvedValue(makeDbSession());
+
+    const res = await POST(
+      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'intruso', rating: 5 }),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe('INVALID_STUDENT');
+  });
+
+  it('returns 422 when the session has not ended yet', async () => {
+    requireTutor.mockReturnValue(TUTOR_AUTH);
+    prisma.session.findUnique.mockResolvedValue(
+      makeDbSession({ endTimestamp: new Date(Date.now() + 3600_000) }),
+    );
+
+    const res = await POST(
+      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 5 }),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body.code).toBe('SESSION_NOT_ENDED');
+  });
+
+  it('returns 422 for canceled sessions', async () => {
+    requireTutor.mockReturnValue(TUTOR_AUTH);
+    prisma.session.findUnique.mockResolvedValue(makeDbSession({ status: 'Canceled' }));
+
+    const res = await POST(
+      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 5 }),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body.code).toBe('SESSION_NOT_ELIGIBLE');
+  });
+});
+
+// ─── GET /api/sessions/:id/student-reviews ──────────────────────────
+
+describe('GET /api/sessions/:id/student-reviews', () => {
+  let GET;
+  beforeAll(() => {
+    GET = require('@/app/api/sessions/[id]/student-reviews/route').GET;
+  });
+
+  it('only ever returns reviews written by the calling tutor', async () => {
+    requireTutor.mockReturnValue(TUTOR_AUTH);
+    prisma.studentReview.findMany.mockResolvedValue([
+      { id: 'sr-1', tutorId: 'tutor-1', studentId: 'student-1', status: 'pending', rating: null },
+    ]);
+
+    const res = await GET(new Request('http://x/api/sessions/session-1/student-reviews'), {
+      params: Promise.resolve({ id: 'session-1' }),
+    });
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.count).toBe(1);
+    // The where clause is pinned to the caller's id — not just the session
+    expect(prisma.studentReview.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { sessionId: 'session-1', tutorId: 'tutor-1' } }),
+    );
+  });
+
+  it('rejects students (guard)', async () => {
+    requireTutor.mockReturnValue(
+      NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 }),
+    );
+
+    const res = await GET(new Request('http://x/api/sessions/session-1/student-reviews'), {
+      params: Promise.resolve({ id: 'session-1' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(prisma.studentReview.findMany).not.toHaveBeenCalled();
+  });
+});
+
+// ─── GET /api/users/me/student-rating ───────────────────────────────
+
+describe('GET /api/users/me/student-rating', () => {
+  let GET;
+  beforeAll(() => {
+    GET = require('@/app/api/users/me/student-rating/route').GET;
+  });
+
+  it('returns the caller own aggregate — number only, no reviews/comments', async () => {
+    authenticateRequest.mockReturnValue(STUDENT_AUTH);
+    prisma.user.findUnique.mockResolvedValue({ studentRating: '4.50', studentRatingCount: 8 });
+
+    const res = await GET(new Request('http://x/api/users/me/student-rating'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, average: 4.5, count: 8 });
+    expect(prisma.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'student-1' } }),
+    );
+  });
+
+  it('requires authentication', async () => {
+    authenticateRequest.mockReturnValue(
+      NextResponse.json({ success: false, error: 'No token' }, { status: 401 }),
+    );
+
+    const res = await GET(new Request('http://x/api/users/me/student-rating'));
+
+    expect(res.status).toBe(401);
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+// ─── PRIVACY: session payload gating ────────────────────────────────
+
+describe('PRIVACY — student rating only reaches tutor payloads', () => {
+  let GET_SESSIONS;
+  let GET_SESSION;
+  beforeAll(() => {
+    GET_SESSIONS = require('@/app/api/sessions/route').GET;
+    GET_SESSION = require('@/app/api/sessions/[id]/route').GET;
+  });
+
+  it('GET /api/sessions?role=tutor attaches studentRating + studentReviews', async () => {
+    authenticateRequest.mockReturnValue(TUTOR_AUTH);
+    prisma.session.findMany.mockResolvedValue([makeDbSession()]);
+    prisma.user.findMany.mockResolvedValue([
+      { id: 'student-1', studentRating: '4.75', studentRatingCount: 12 },
+    ]);
+    prisma.studentReview.findMany.mockResolvedValue([
+      { id: 'sr-1', sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1', status: 'pending', rating: null },
+    ]);
+
+    const res = await GET_SESSIONS(new Request('http://x/api/sessions?role=tutor'));
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    const participant = body.sessions[0].participants[0];
+    expect(participant.student.studentRating).toBe(4.75);
+    expect(participant.student.studentRatingCount).toBe(12);
+    expect(body.sessions[0].studentReviews).toHaveLength(1);
+  });
+
+  it('GET /api/sessions (student) never queries nor attaches ratings', async () => {
+    authenticateRequest.mockReturnValue(STUDENT_AUTH);
+    prisma.session.findMany.mockResolvedValue([makeDbSession()]);
+
+    const res = await GET_SESSIONS(new Request('http://x/api/sessions'));
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    const participant = body.sessions[0].participants[0];
+    expect(participant.student.studentRating).toBeUndefined();
+    expect(body.sessions[0].studentReviews).toBeUndefined();
+    // The ratings batch query must not run for student payloads
+    expect(prisma.user.findMany).not.toHaveBeenCalled();
+    expect(prisma.studentReview.findMany).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/sessions/:id enriches only when the caller is the session tutor', async () => {
+    authenticateRequest.mockReturnValue(TUTOR_AUTH);
+    prisma.session.findUnique.mockResolvedValue(makeDbSession());
+    prisma.user.findMany.mockResolvedValue([
+      { id: 'student-1', studentRating: '4.75', studentRatingCount: 12 },
+    ]);
+
+    const res = await GET_SESSION(new Request('http://x/api/sessions/session-1'), {
+      params: Promise.resolve({ id: 'session-1' }),
+    });
+    const body = await res.json();
+
+    expect(body.session.participants[0].student.studentRating).toBe(4.75);
+    expect(body.session.studentReviews).toBeDefined();
+  });
+
+  it('GET /api/sessions/:id gives students a payload without ratings', async () => {
+    authenticateRequest.mockReturnValue(STUDENT_AUTH);
+    prisma.session.findUnique.mockResolvedValue(makeDbSession());
+
+    const res = await GET_SESSION(new Request('http://x/api/sessions/session-1'), {
+      params: Promise.resolve({ id: 'session-1' }),
+    });
+    const body = await res.json();
+
+    expect(body.session.participants[0].student.studentRating).toBeUndefined();
+    expect(body.session.studentReviews).toBeUndefined();
+    expect(prisma.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('sanitizeUser (used by login/request-tutor) strips private rating fields', () => {
+    const { sanitizeUser } = require('@/lib/repositories/user.repository');
+    const clean = sanitizeUser({
+      id: 'u1',
+      name: 'Ana',
+      email: 'ana@test.co',
+      passwordHash: 'hash',
+      studentRating: '3.20',
+      studentRatingCount: 5,
+    });
+
+    expect(clean).toEqual({ id: 'u1', name: 'Ana', email: 'ana@test.co' });
+  });
+
+  it('GET /api/users/:id strips the private rating fields (sanitize)', async () => {
+    authenticateRequest.mockReturnValue(STUDENT_AUTH);
+    // Simulate the DB row carrying the private fields
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'student-9',
+      name: 'Otro Estudiante',
+      email: 'otro@test.co',
+      studentRating: '2.10',
+      studentRatingCount: 4,
+      passwordHash: 'x',
+      tutorProfile: null,
+      career: null,
+      tutorApplications: [],
+    });
+
+    const GET_USER = require('@/app/api/users/[id]/route').GET;
+    const res = await GET_USER(new Request('http://x/api/users/student-9'), {
+      params: Promise.resolve({ id: 'student-9' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.user.studentRating).toBeUndefined();
+    expect(body.user.studentRatingCount).toBeUndefined();
+    expect(body.user.passwordHash).toBeUndefined();
+  });
+});

--- a/src/__tests__/services/admin-users.service.test.js
+++ b/src/__tests__/services/admin-users.service.test.js
@@ -24,6 +24,8 @@ jest.mock('@/lib/prisma', () => ({
     user: { findUnique: jest.fn(), findMany: jest.fn(), count: jest.fn() },
     tutorCourse: { findMany: jest.fn() },
     session: { findMany: jest.fn() },
+    studentReview: { findMany: jest.fn() },
+    review: { findMany: jest.fn() },
   },
 }));
 
@@ -56,6 +58,8 @@ function primeStats(overrides = {}) {
   statsRepo.monthlyActivity.mockResolvedValue({ tutor: [], student: [] });
   prisma.tutorCourse.findMany.mockResolvedValue([]);
   prisma.session.findMany.mockResolvedValue([]);
+  prisma.studentReview.findMany.mockResolvedValue([]);
+  prisma.review.findMany.mockResolvedValue([]);
 }
 
 describe('admin-users.service', () => {
@@ -159,6 +163,77 @@ describe('admin-users.service', () => {
       const { select } = prisma.user.findMany.mock.calls[0][0];
       for (const field of SENSITIVE) expect(select[field]).toBeUndefined();
       expect(select.email).toBe(true);
+    });
+
+    it('defaults to most-recent ordering', async () => {
+      await service.listUsers({ role: 'all' });
+      const { orderBy } = prisma.user.findMany.mock.calls[0][0];
+      expect(orderBy).toEqual([{ createdAt: 'desc' }]);
+    });
+
+    it('sort=tutorBest ranks by tutor rating and excludes unrated tutors', async () => {
+      await service.listUsers({ role: 'tutors', sort: 'tutorBest' });
+      const { where, orderBy } = prisma.user.findMany.mock.calls[0][0];
+      expect(where).toMatchObject({
+        isTutorApproved: true,
+        tutorProfile: { numReview: { gt: 0 } },
+      });
+      expect(orderBy).toEqual([{ tutorProfile: { review: 'desc' } }, { createdAt: 'desc' }]);
+    });
+
+    it('sort=studentWorst ranks ascending by student rating and excludes unrated students', async () => {
+      await service.listUsers({ role: 'all', sort: 'studentWorst' });
+      const { where, orderBy } = prisma.user.findMany.mock.calls[0][0];
+      expect(where).toMatchObject({ studentRatingCount: { gt: 0 } });
+      expect(orderBy).toEqual([{ studentRating: 'asc' }, { createdAt: 'desc' }]);
+    });
+
+    it('falls back to recent on unknown sort values', async () => {
+      await service.listUsers({ role: 'all', sort: 'hacker' });
+      const { orderBy, where } = prisma.user.findMany.mock.calls[0][0];
+      expect(orderBy).toEqual([{ createdAt: 'desc' }]);
+      expect(where.studentRatingCount).toBeUndefined();
+    });
+
+    it('count uses the same where as the page query (total matches the filter)', async () => {
+      await service.listUsers({ role: 'all', sort: 'studentBest' });
+      const findWhere = prisma.user.findMany.mock.calls[0][0].where;
+      const countWhere = prisma.user.count.mock.calls[0][0].where;
+      expect(countWhere).toEqual(findWhere);
+    });
+  });
+
+  describe('getUserProfile — reviews on both sides', () => {
+    it('includes tutorReviewsReceived for approved tutors', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'u1', name: 'Ana', isTutorApproved: true,
+        tutorProfile: { review: 4.5, numReview: 3 },
+        _count: {},
+      });
+      primeStats();
+      prisma.review.findMany.mockResolvedValue([
+        { id: 'r1', rating: 5, comment: 'Excelente tutor', student: { id: 's1', name: 'Luis' } },
+      ]);
+      prisma.studentReview.findMany.mockResolvedValue([
+        { id: 'sr1', rating: 4, comment: 'Buen estudiante', tutor: { id: 't1', name: 'Marta' } },
+      ]);
+
+      const p = await service.getUserProfile('u1');
+
+      expect(p.tutorReviewsReceived).toHaveLength(1);
+      expect(p.tutorReviewsReceived[0].comment).toBe('Excelente tutor');
+      expect(p.studentReviewsReceived).toHaveLength(1);
+      expect(p.studentReviewsReceived[0].comment).toBe('Buen estudiante');
+    });
+
+    it('skips the tutor-reviews query for plain students', async () => {
+      prisma.user.findUnique.mockResolvedValue({ id: 'u1', name: 'Ana', isTutorApproved: false, _count: {} });
+      primeStats();
+
+      const p = await service.getUserProfile('u1');
+
+      expect(p.tutorReviewsReceived).toEqual([]);
+      expect(prisma.review.findMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/services/session-cancel-stats.test.js
+++ b/src/__tests__/services/session-cancel-stats.test.js
@@ -30,6 +30,11 @@ jest.mock('@/lib/repositories/user.repository', () => ({
 jest.mock('@/lib/services/notification.service', () => ({
   notifySessionCancelled: jest.fn(),
   notifySessionCompleted: jest.fn(),
+  notifyRateStudents: jest.fn(),
+}));
+
+jest.mock('@/lib/repositories/student-review.repository', () => ({
+  createPendingStudentReview: jest.fn().mockResolvedValue({}),
 }));
 
 jest.mock('@/lib/services/calico-calendar.service', () => ({

--- a/src/__tests__/services/session.notifications.test.js
+++ b/src/__tests__/services/session.notifications.test.js
@@ -19,6 +19,7 @@ jest.mock('@/lib/repositories/session.repository');
 jest.mock('@/lib/repositories/availability.repository');
 jest.mock('@/lib/repositories/user.repository');
 jest.mock('@/lib/repositories/review.repository');
+jest.mock('@/lib/repositories/student-review.repository');
 jest.mock('@/lib/repositories/tutor-profile.repository');
 jest.mock('@/lib/repositories/payment.repository');
 jest.mock('@/lib/services/calico-calendar.service');
@@ -29,6 +30,7 @@ const sessionRepo = require('@/lib/repositories/session.repository');
 const availabilityRepo = require('@/lib/repositories/availability.repository');
 const userRepo = require('@/lib/repositories/user.repository');
 const reviewRepo = require('@/lib/repositories/review.repository');
+const studentReviewRepo = require('@/lib/repositories/student-review.repository');
 const tutorProfileRepo = require('@/lib/repositories/tutor-profile.repository');
 const paymentRepo = require('@/lib/repositories/payment.repository');
 const calicoCalendar = require('@/lib/services/calico-calendar.service');
@@ -74,6 +76,38 @@ describe('Session Completion — Notifications', () => {
       expect.objectContaining({ id: 'sess-1', tutorId: 'tutor-1' }),
       'Prof. García',
     );
+  });
+
+  it('reminds the tutor to rate students and creates pending placeholders (reciprocal review)', async () => {
+    const tutor = { id: 'tutor-1', name: 'Prof. García', email: 'prof@example.com' };
+    const session = {
+      id: 'sess-1',
+      tutorId: 'tutor-1',
+      courseId: 'course-1',
+      status: 'Accepted',
+      course: { name: 'Cálculo' },
+      participants: [
+        { studentId: 'student-1', student: { id: 'student-1', name: 'Alice' } },
+        { studentId: 'student-2', student: { id: 'student-2', name: 'Bob' } },
+      ],
+      tutor,
+    };
+
+    sessionRepo.findById.mockResolvedValue(session);
+    sessionRepo.updateSession.mockResolvedValue({ ...session, status: 'Completed' });
+    userRepo.findById.mockResolvedValue(tutor);
+    paymentRepo.findBySessionId.mockResolvedValue(null);
+    reviewRepo.upsertReview.mockResolvedValue({});
+    studentReviewRepo.createPendingStudentReview.mockResolvedValue({});
+
+    await sessionService.completeSession('sess-1', 'tutor-1');
+
+    expect(notificationService.notifyRateStudents).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'sess-1', tutorId: 'tutor-1' }),
+    );
+    expect(studentReviewRepo.createPendingStudentReview).toHaveBeenCalledTimes(2);
+    expect(studentReviewRepo.createPendingStudentReview).toHaveBeenCalledWith('sess-1', 'tutor-1', 'student-1');
+    expect(studentReviewRepo.createPendingStudentReview).toHaveBeenCalledWith('sess-1', 'tutor-1', 'student-2');
   });
 });
 

--- a/src/__tests__/services/student-review.service.test.js
+++ b/src/__tests__/services/student-review.service.test.js
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for student-review.service (tutor→student reciprocal reviews).
+ * Mocks the repositories to verify business rules in isolation.
+ */
+
+jest.mock('@/lib/repositories/student-review.repository', () => ({
+  upsertStudentReview: jest.fn(),
+  updateStudentRatingStats: jest.fn(),
+  findBySessionForTutor: jest.fn(),
+  findReceivedByStudent: jest.fn(),
+  getStudentRating: jest.fn(),
+}));
+
+jest.mock('@/lib/repositories/session.repository', () => ({
+  findById: jest.fn(),
+}));
+
+const studentReviewRepo = require('@/lib/repositories/student-review.repository');
+const sessionRepo = require('@/lib/repositories/session.repository');
+const service = require('@/lib/services/student-review.service');
+
+const TUTOR_ID = 'tutor-1';
+const STUDENT_ID = 'student-1';
+const SESSION_ID = 'session-1';
+
+function makeSession(overrides = {}) {
+  const past = new Date(Date.now() - 60 * 60 * 1000); // ended 1h ago
+  return {
+    id: SESSION_ID,
+    tutorId: TUTOR_ID,
+    status: 'Completed',
+    endTimestamp: past.toISOString(),
+    participants: [{ studentId: STUDENT_ID }],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  studentReviewRepo.findBySessionForTutor.mockResolvedValue([]);
+  studentReviewRepo.upsertStudentReview.mockImplementation(async (data) => ({ id: 'sr-1', ...data }));
+  studentReviewRepo.updateStudentRatingStats.mockResolvedValue({});
+});
+
+describe('createStudentReview — validations', () => {
+  it.each([0, 6, 3.5, '5', null, undefined])(
+    'rejects invalid rating %p with INVALID_RATING',
+    async (rating) => {
+      await expect(
+        service.createStudentReview(SESSION_ID, TUTOR_ID, { studentId: STUDENT_ID, rating }),
+      ).rejects.toMatchObject({ code: 'INVALID_RATING' });
+      expect(sessionRepo.findById).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects when session does not exist (NOT_FOUND)', async () => {
+    sessionRepo.findById.mockResolvedValue(null);
+
+    await expect(
+      service.createStudentReview(SESSION_ID, TUTOR_ID, { studentId: STUDENT_ID, rating: 5 }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('rejects when session has not ended yet (SESSION_NOT_ENDED)', async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+    sessionRepo.findById.mockResolvedValue(makeSession({ endTimestamp: future.toISOString() }));
+
+    await expect(
+      service.createStudentReview(SESSION_ID, TUTOR_ID, { studentId: STUDENT_ID, rating: 5 }),
+    ).rejects.toMatchObject({ code: 'SESSION_NOT_ENDED' });
+  });
+
+  it.each(['Canceled', 'Rejected'])(
+    'rejects %s sessions (SESSION_NOT_ELIGIBLE)',
+    async (status) => {
+      sessionRepo.findById.mockResolvedValue(makeSession({ status }));
+
+      await expect(
+        service.createStudentReview(SESSION_ID, TUTOR_ID, { studentId: STUDENT_ID, rating: 4 }),
+      ).rejects.toMatchObject({ code: 'SESSION_NOT_ELIGIBLE' });
+    },
+  );
+
+  it('rejects when caller is not the session tutor (NOT_SESSION_TUTOR)', async () => {
+    sessionRepo.findById.mockResolvedValue(makeSession());
+
+    await expect(
+      service.createStudentReview(SESSION_ID, 'another-tutor', { studentId: STUDENT_ID, rating: 4 }),
+    ).rejects.toMatchObject({ code: 'NOT_SESSION_TUTOR' });
+    expect(studentReviewRepo.upsertStudentReview).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the reviewee did not participate (INVALID_STUDENT)', async () => {
+    sessionRepo.findById.mockResolvedValue(makeSession());
+
+    await expect(
+      service.createStudentReview(SESSION_ID, TUTOR_ID, { studentId: 'intruso', rating: 4 }),
+    ).rejects.toMatchObject({ code: 'INVALID_STUDENT' });
+    expect(studentReviewRepo.upsertStudentReview).not.toHaveBeenCalled();
+  });
+});
+
+describe('createStudentReview — happy path', () => {
+  it('upserts as done and recomputes the student aggregate', async () => {
+    sessionRepo.findById.mockResolvedValue(makeSession());
+
+    const result = await service.createStudentReview(SESSION_ID, TUTOR_ID, {
+      studentId: STUDENT_ID,
+      rating: 4,
+      comment: 'Muy puntual',
+    });
+
+    expect(studentReviewRepo.upsertStudentReview).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      tutorId: TUTOR_ID,
+      studentId: STUDENT_ID,
+      rating: 4,
+      status: 'done',
+      comment: 'Muy puntual',
+    });
+    expect(studentReviewRepo.updateStudentRatingStats).toHaveBeenCalledWith(STUDENT_ID);
+    expect(result.updated).toBe(false);
+    expect(result.review).toMatchObject({ rating: 4, status: 'done' });
+  });
+
+  it('normalizes empty comment to null', async () => {
+    sessionRepo.findById.mockResolvedValue(makeSession());
+
+    await service.createStudentReview(SESSION_ID, TUTOR_ID, {
+      studentId: STUDENT_ID,
+      rating: 5,
+      comment: '',
+    });
+
+    expect(studentReviewRepo.upsertStudentReview).toHaveBeenCalledWith(
+      expect.objectContaining({ comment: null }),
+    );
+  });
+
+  it('flags updated=true when editing an already-done review', async () => {
+    sessionRepo.findById.mockResolvedValue(makeSession());
+    studentReviewRepo.findBySessionForTutor.mockResolvedValue([
+      { sessionId: SESSION_ID, tutorId: TUTOR_ID, studentId: STUDENT_ID, status: 'done', rating: 3 },
+    ]);
+
+    const result = await service.createStudentReview(SESSION_ID, TUTOR_ID, {
+      studentId: STUDENT_ID,
+      rating: 5,
+    });
+
+    expect(result.updated).toBe(true);
+    expect(studentReviewRepo.updateStudentRatingStats).toHaveBeenCalledWith(STUDENT_ID);
+  });
+
+  it('allows rating a session that ended but was never marked Completed', async () => {
+    // Mirrors the student→tutor flow: eligibility is "ended + not canceled",
+    // not strictly status === Completed.
+    sessionRepo.findById.mockResolvedValue(makeSession({ status: 'Accepted' }));
+
+    const result = await service.createStudentReview(SESSION_ID, TUTOR_ID, {
+      studentId: STUDENT_ID,
+      rating: 4,
+    });
+
+    expect(result.review.status).toBe('done');
+  });
+
+  it('rates each participant independently in group sessions', async () => {
+    sessionRepo.findById.mockResolvedValue(
+      makeSession({ participants: [{ studentId: 'a' }, { studentId: 'b' }] }),
+    );
+
+    await service.createStudentReview(SESSION_ID, TUTOR_ID, { studentId: 'b', rating: 2 });
+
+    expect(studentReviewRepo.upsertStudentReview).toHaveBeenCalledWith(
+      expect.objectContaining({ studentId: 'b', rating: 2 }),
+    );
+    expect(studentReviewRepo.updateStudentRatingStats).toHaveBeenCalledWith('b');
+  });
+});
+
+describe('read helpers', () => {
+  it('getSessionStudentReviewsForTutor delegates filtered by tutor', async () => {
+    studentReviewRepo.findBySessionForTutor.mockResolvedValue([{ id: 'sr-1' }]);
+
+    const result = await service.getSessionStudentReviewsForTutor(SESSION_ID, TUTOR_ID);
+
+    expect(studentReviewRepo.findBySessionForTutor).toHaveBeenCalledWith(SESSION_ID, TUTOR_ID);
+    expect(result).toEqual([{ id: 'sr-1' }]);
+  });
+
+  it('getOwnStudentRating returns the aggregate number only', async () => {
+    studentReviewRepo.getStudentRating.mockResolvedValue({ average: 4.5, count: 8 });
+
+    const result = await service.getOwnStudentRating(STUDENT_ID);
+
+    expect(result).toEqual({ average: 4.5, count: 8 });
+  });
+});

--- a/src/app/api/admin/users/route.js
+++ b/src/app/api/admin/users/route.js
@@ -3,10 +3,12 @@
  * Searchable directory of ALL users (students, tutors, admins). Filters:
  *   ?role=all|students|tutors|admins|suspended   (default: all)
  *   ?search=<text>                               (matches name OR email)
+ *   ?sort=recent|tutorBest|tutorWorst|studentBest|studentWorst (default: recent)
  *   ?limit=<n>&offset=<n>
  *
  * Auth: admin user (JWT + role lookup in DB). Returns confidential contact
- * info, so it MUST stay behind requireAdminUser.
+ * info (incl. the private student rating), so it MUST stay behind
+ * requireAdminUser.
  */
 
 export const dynamic = 'force-dynamic';
@@ -16,6 +18,7 @@ import { requireAdminUser } from '@/lib/auth/guards';
 import * as usersService from '@/lib/services/admin-users.service';
 
 const ALLOWED_ROLES = new Set(['all', 'students', 'tutors', 'admins', 'suspended']);
+const ALLOWED_SORTS = new Set(usersService.LIST_SORT_KEYS);
 
 export async function GET(request) {
   const auth = await requireAdminUser(request);
@@ -24,12 +27,14 @@ export async function GET(request) {
   const { searchParams } = new URL(request.url);
   const rawRole = searchParams.get('role') ?? 'all';
   const role    = ALLOWED_ROLES.has(rawRole) ? rawRole : 'all';
+  const rawSort = searchParams.get('sort') ?? 'recent';
+  const sort    = ALLOWED_SORTS.has(rawSort) ? rawSort : 'recent';
   const search  = searchParams.get('search')?.trim() || undefined;
   const limit   = Math.max(1, Math.min(parseInt(searchParams.get('limit')  ?? '50', 10) || 50, 200));
   const offset  = Math.max(0, parseInt(searchParams.get('offset') ?? '0', 10) || 0);
 
   try {
-    const { items, total } = await usersService.listUsers({ role, search, limit, offset });
+    const { items, total } = await usersService.listUsers({ role, search, sort, limit, offset });
     return NextResponse.json({ success: true, users: items, total });
   } catch (err) {
     console.error('[GET /api/admin/users]', err);

--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -74,10 +74,10 @@ export async function POST(request) {
       console.warn('[login] touchLastSeen failed:', err?.message);
     });
 
-    // 4. Sign JWT and return (strip sensitive fields from response)
+    // 4. Sign JWT and return (strip sensitive + private fields from response)
     const token = signToken(user);
 
-    const { passwordHash, verificationToken, resetToken, resetTokenExpiry, otpCode, otpCodeExpiry, ...safeUser } = user;
+    const safeUser = userRepository.sanitizeUser(user);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/auth/request-tutor/route.js
+++ b/src/app/api/auth/request-tutor/route.js
@@ -9,6 +9,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import prisma from '@/lib/prisma';
 import { authenticateRequest } from '@/lib/auth/middleware';
+import { sanitizeUser } from '@/lib/repositories/user.repository';
 
 const requestTutorSchema = z.object({
   schoolEmail: z
@@ -82,8 +83,8 @@ export async function POST(request) {
       return updatedUser;
     });
 
-    // Strip sensitive fields
-    const { passwordHash, verificationToken, resetToken, resetTokenExpiry, otpCode, otpCodeExpiry, ...safeUser } = result;
+    // Strip sensitive + private fields (single strip list in user.repository)
+    const safeUser = sanitizeUser(result);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/auth/verify-otp/route.js
+++ b/src/app/api/auth/verify-otp/route.js
@@ -7,13 +7,18 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import * as userService from '@/lib/services/user.service';
+import { rateLimit, getClientIp } from '@/lib/auth/rateLimit';
 
 const schema = z.object({
-  email: z.string().email(),
+  email: z.string().trim().toLowerCase().email(),
   otpCode: z.string().length(6, 'OTP must be 6 digits'),
 });
 
 export async function POST(request) {
+  // Per-IP limit first: blocks broad scanning before we touch the DB.
+  const ipLimited = rateLimit(`otp-verify:ip:${getClientIp(request)}`, { max: 20, windowMs: 15 * 60_000 });
+  if (ipLimited) return ipLimited;
+
   try {
     const body = await request.json();
     const parsed = schema.safeParse(body);
@@ -26,6 +31,13 @@ export async function POST(request) {
     }
 
     const { email, otpCode } = parsed.data;
+
+    // Per-email limit: a 6-digit OTP is only ~1M combinations, so without this
+    // an attacker who knows the victim's email could brute-force the code and
+    // take over the account. Cap attempts per email to make that infeasible.
+    const emailLimited = rateLimit(`otp-verify:email:${email}`, { max: 5, windowMs: 15 * 60_000 });
+    if (emailLimited) return emailLimited;
+
     const result = await userService.verifyOtp(email, otpCode);
 
     if (!result.valid) {

--- a/src/app/api/payments/student/[email]/route.js
+++ b/src/app/api/payments/student/[email]/route.js
@@ -1,11 +1,21 @@
 /**
  * GET /api/payments/student/[email]
- * Get payment history for a student by email
+ * Get payment history for a student by email.
+ *
+ * Auth: Required. Returns a student's full financial history, so only that
+ *       student (matched by the JWT's email) or an admin may read it. The
+ *       requester identity comes from the JWT — never from the URL param.
  */
 
+import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { authenticateRequest } from '@/lib/auth/middleware';
+import { isAdmin } from '@/lib/auth/guards';
 
 export async function GET(request, { params }) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const resolvedParams = await params;
     const { email } = resolvedParams;
@@ -17,9 +27,20 @@ export async function GET(request, { params }) {
       );
     }
 
+    // Normalize to match how emails are stored/compared (lowercased at register).
+    const normalizedEmail = decodeURIComponent(email).trim().toLowerCase();
+
+    // Authorization: only the owner of this email, or an admin, may read it.
+    if (
+      String(auth.email ?? '').trim().toLowerCase() !== normalizedEmail &&
+      !(await isAdmin(auth.sub))
+    ) {
+      return Response.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
     // Find user by email
     const user = await prisma.user.findUnique({
-      where: { email },
+      where: { email: normalizedEmail },
     });
 
     if (!user) {

--- a/src/app/api/payments/tutor/[tutorId]/route.js
+++ b/src/app/api/payments/tutor/[tutorId]/route.js
@@ -1,11 +1,21 @@
 /**
  * GET /api/payments/tutor/[tutorId]
- * Retrieves all payments for a specific tutor
+ * Retrieves all payments for a specific tutor.
+ *
+ * Auth: Required. Returns confidential data (student names + emails, amounts),
+ *       so only the tutor themselves or an admin may read it. The requester
+ *       identity comes from the JWT — never from the URL.
  */
 
+import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { authenticateRequest } from '@/lib/auth/middleware';
+import { isAdmin } from '@/lib/auth/guards';
 
 export async function GET(request, { params }) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const resolvedParams = await params;
     const { tutorId } = resolvedParams;
@@ -13,6 +23,11 @@ export async function GET(request, { params }) {
     const tutorIdStr = String(tutorId ?? '').trim();
     if (!tutorIdStr) {
       return Response.json({ error: 'Tutor ID is required' }, { status: 400 });
+    }
+
+    // Authorization: only the tutor themselves, or an admin, may read these payments.
+    if (String(auth.sub) !== tutorIdStr && !(await isAdmin(auth.sub))) {
+      return Response.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     // Payment.tutorId matches User.id (String — UUID or legacy string id)

--- a/src/app/api/sessions/[id]/route.js
+++ b/src/app/api/sessions/[id]/route.js
@@ -15,7 +15,14 @@ export async function GET(request, { params }) {
   const { id } = await params;
 
   try {
-    const session = await sessionService.getSessionById(id);
+    let session = await sessionService.getSessionById(id);
+
+    // Tutor-only enrichment: participants' private student rating (estilo
+    // Uber) + the reviews this tutor wrote. Students never get these fields.
+    if (session.tutorId === auth.sub) {
+      session = await sessionService.enrichSessionForTutor(session, auth.sub);
+    }
+
     return NextResponse.json({ success: true, session });
   } catch (err) {
     if (err.code === 'NOT_FOUND') {

--- a/src/app/api/sessions/[id]/student-reviews/route.js
+++ b/src/app/api/sessions/[id]/student-reviews/route.js
@@ -1,0 +1,83 @@
+/**
+ * POST /api/sessions/:id/student-reviews — Tutor rates a student of a finished session
+ * GET  /api/sessions/:id/student-reviews — Reviews the calling tutor wrote for this session
+ *
+ * PRIVACY: tutor→student reviews are never public. This route only ever
+ * returns reviews authored by the authenticated tutor (their own), and only
+ * the session's assigned tutor can create one. Students have no read access
+ * to individual reviews — they only see their aggregate via
+ * GET /api/users/me/student-rating.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireTutor } from '@/lib/auth/guards';
+import * as studentReviewService from '@/lib/services/student-review.service';
+
+const createStudentReviewSchema = z.object({
+  studentId: z.union([z.string(), z.number()]).transform(String),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(1000).optional(),
+});
+
+export async function POST(request, { params }) {
+  const auth = requireTutor(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const { id: sessionId } = await params;
+  const body = await request.json();
+  const parsed = createStudentReviewSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error.issues[0].message },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await studentReviewService.createStudentReview(sessionId, auth.sub, parsed.data);
+
+    return NextResponse.json(
+      {
+        success: true,
+        review: result.review,
+        updated: result.updated,
+      },
+      { status: result.updated ? 200 : 201 },
+    );
+  } catch (err) {
+    const statusMap = {
+      NOT_FOUND: 404,
+      NOT_SESSION_TUTOR: 403,
+      INVALID_STUDENT: 400,
+      INVALID_RATING: 400,
+      SESSION_NOT_ENDED: 422,
+      SESSION_NOT_ELIGIBLE: 422,
+    };
+
+    const status = statusMap[err.code];
+    if (status) {
+      return NextResponse.json(
+        { success: false, error: err.message, code: err.code },
+        { status },
+      );
+    }
+
+    throw err;
+  }
+}
+
+export async function GET(request, { params }) {
+  const auth = requireTutor(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const { id: sessionId } = await params;
+
+  // Filtered by the caller's own tutorId — a tutor can only read what they wrote.
+  const reviews = await studentReviewService.getSessionStudentReviewsForTutor(sessionId, auth.sub);
+
+  return NextResponse.json({ success: true, reviews, count: reviews.length });
+}

--- a/src/app/api/users/me/student-rating/route.js
+++ b/src/app/api/users/me/student-rating/route.js
@@ -1,0 +1,32 @@
+/**
+ * GET /api/users/me/student-rating — The caller's own aggregate rating as a
+ * student (tutor→student reviews, estilo Uber).
+ *
+ * Returns ONLY the number ({ average, count }) — never the individual reviews
+ * or comments, which stay private (tutor who wrote them + admin only).
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { authenticateRequest } from '@/lib/auth/middleware';
+import * as studentReviewService from '@/lib/services/student-review.service';
+
+export async function GET(request) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const rating = await studentReviewService.getOwnStudentRating(auth.sub);
+  if (!rating) {
+    return NextResponse.json(
+      { success: false, error: 'Usuario no encontrado' },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    average: rating.average,
+    count: rating.count,
+  });
+}

--- a/src/app/components/NotificationDropdown/NotificationDropdown.jsx
+++ b/src/app/components/NotificationDropdown/NotificationDropdown.jsx
@@ -1,18 +1,19 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
-import { 
-  Bell, 
-  X, 
-  Check, 
-  Clock, 
-  User, 
+import {
+  Bell,
+  X,
+  Check,
+  Clock,
+  User,
   Calendar,
   MessageSquare,
   AlertCircle,
   CheckCircle,
   XCircle,
-  CreditCard
+  CreditCard,
+  Star
 } from "lucide-react";
 import { NotificationService } from "../../services/core/NotificationService";
 import { TutoringSessionService } from "../../services/core/TutoringSessionService";
@@ -144,6 +145,8 @@ export default function NotificationDropdown() {
           return <Calendar className="notification-icon reminder" />;
         case 'session_reminder':
           return <Calendar className="notification-icon reminder" />;
+        case 'student_review_reminder':
+          return <Star className="notification-icon reminder" />;
         case 'message':
         case 'tutor_message':
           return <MessageSquare className="notification-icon message" />;
@@ -177,6 +180,8 @@ export default function NotificationDropdown() {
           return t('notifications.tutor.sessionConfirmed');
         case 'session_reminder':
           return t('notifications.tutor.sessionReminder');
+        case 'student_review_reminder':
+          return t('notifications.tutor.studentReviewReminder');
         case 'message':
         case 'tutor_message':
           return t('notifications.tutor.message');
@@ -255,6 +260,16 @@ export default function NotificationDropdown() {
             setIsOpen(false);
           }
           break;
+        case 'student_review_reminder': {
+          // Open the session detail — it hosts the "Calificar estudiante" flow
+          const completedSessionData = await getSessionData(notification.sessionId);
+          if (completedSessionData) {
+            setSelectedSession(completedSessionData);
+            setShowTutorSessionModal(true);
+            setIsOpen(false);
+          }
+          break;
+        }
         case 'session_reminder':
           router.push(routes.TUTOR_DISPONIBILIDAD);
           setIsOpen(false);

--- a/src/app/components/SessionDetailView/SessionDetailView.jsx
+++ b/src/app/components/SessionDetailView/SessionDetailView.jsx
@@ -29,12 +29,14 @@ import {
   ArrowLeft,
   Loader2,
   Paperclip,
+  Star,
 } from 'lucide-react';
 import { useAuth } from '../../context/SecureAuthContext';
 import { TutoringSessionService } from '../../services/core/TutoringSessionService';
 import { authFetch } from '../../services/authFetch';
 import AttachmentList from '../AttachmentList/AttachmentList';
 import CancellationModal from '../CancellationModal/CancellationModal';
+import StudentReviewModal from '../StudentReviewModal/StudentReviewModal';
 
 // ─── Status helpers ──────────────────────────────────────────────────────────
 
@@ -90,6 +92,7 @@ export default function SessionDetailView({ sessionId, session: initialSession, 
   const [actionLoading, setActionLoading] = useState(null); // 'accept' | 'reject' | 'cancel' | null
   const [actionError, setActionError] = useState(null);
   const [showCancellationModal, setShowCancellationModal] = useState(false);
+  const [showStudentReviewModal, setShowStudentReviewModal] = useState(false);
   const currentSessionId = sessionId || initialSession?.id || session?.id || null;
 
   // ─── Fetch session ─────────────────────────────────────────────────────────
@@ -220,8 +223,15 @@ export default function SessionDetailView({ sessionId, session: initialSession, 
 
   const showActions = session?.status === 'Pending' && isTutor;
 
-  // Student info (first participant)
-  const student = session?.participants?.[0]?.student;
+  // Reciprocal review state (tutor → student, only present on tutor payloads).
+  // With no rows yet (sessions completed before the feature) the tutor can
+  // still rate — the server creates the row on submit.
+  const studentReviews = session?.studentReviews || [];
+  const hasRatedAllStudents =
+    studentReviews.length > 0 &&
+    studentReviews.length >= (session?.participants?.length || 0) &&
+    studentReviews.every((r) => r.status === 'done');
+  const canRateStudents = isTutor && session?.status === 'Completed';
 
   // ─── Render ────────────────────────────────────────────────────────────────
 
@@ -392,21 +402,64 @@ export default function SessionDetailView({ sessionId, session: initialSession, 
             </p>
           </div>
         )}
+        {canRateStudents && (
+          <div className="flex items-center justify-between gap-3 flex-wrap rounded-xl bg-blue-50 border border-blue-200 p-4 mb-6">
+            <div className="flex items-center gap-3 min-w-0">
+              <Star className="w-5 h-5 text-blue-600 shrink-0" />
+              <p className="text-sm text-blue-800 font-medium">
+                {hasRatedAllStudents
+                  ? 'Ya calificaste esta tutoría. Puedes editar tu calificación.'
+                  : '¿Cómo te fue? Califica a tu estudiante — la calificación es privada.'}
+              </p>
+            </div>
+            <button
+              onClick={() => setShowStudentReviewModal(true)}
+              className="px-4 py-2 bg-[#006bb3] text-white text-sm font-semibold rounded-lg hover:bg-[#005694] transition-colors shrink-0"
+            >
+              {hasRatedAllStudents
+                ? 'Editar calificación'
+                : (session.participants?.length || 0) > 1
+                ? 'Calificar estudiantes'
+                : 'Calificar estudiante'}
+            </button>
+          </div>
+        )}
 
         {/* Content cards */}
         <div className="space-y-4">
           {/* Person info — tutors see student, students see tutor */}
           {isTutor && (
             <div className="bg-white rounded-xl border border-gray-100 p-5 shadow-sm">
-              <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">Estudiante</h3>
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-full bg-orange-50 flex items-center justify-center text-[#FF8C00]">
-                  <User className="w-5 h-5" />
-                </div>
-                <div className="min-w-0">
-                  <p className="font-semibold text-gray-900 truncate">{student?.name || 'Estudiante'}</p>
-                  <p className="text-sm text-gray-500 truncate">{student?.email}</p>
-                </div>
+              <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
+                {(session.participants?.length || 0) > 1 ? 'Estudiantes' : 'Estudiante'}
+              </h3>
+              <div className="space-y-3">
+                {(session.participants || []).map((p) => (
+                  <div key={p.studentId} className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-full bg-orange-50 flex items-center justify-center text-[#FF8C00]">
+                      <User className="w-5 h-5" />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="font-semibold text-gray-900 truncate">{p.student?.name || 'Estudiante'}</p>
+                      <p className="text-sm text-gray-500 truncate">{p.student?.email}</p>
+                      {/* Private student rating (estilo Uber) — only present on tutor payloads */}
+                      {p.student?.studentRatingCount > 0 ? (
+                        <p className="text-xs text-gray-600 flex items-center gap-1 mt-0.5">
+                          <Star className="w-3.5 h-3.5 text-yellow-500 fill-yellow-500" />
+                          <span className="font-semibold">{Number(p.student.studentRating).toFixed(1)}</span>
+                          <span className="text-gray-400">
+                            · {p.student.studentRatingCount}{' '}
+                            {p.student.studentRatingCount === 1 ? 'calificación' : 'calificaciones'}
+                          </span>
+                        </p>
+                      ) : p.student?.studentRatingCount === 0 ? (
+                        <span className="inline-block text-[10px] font-semibold uppercase tracking-wide bg-blue-50 text-blue-700 rounded-full px-2 py-0.5 mt-0.5">
+                          Nuevo
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           )}
@@ -603,6 +656,15 @@ export default function SessionDetailView({ sessionId, session: initialSession, 
           session={session}
           onCancellationSuccess={handleCancellationSuccess}
           currentUser={user}
+        />
+      )}
+
+      {/* Rate-students Modal (tutor → student, private) */}
+      {showStudentReviewModal && (
+        <StudentReviewModal
+          session={session}
+          onClose={() => setShowStudentReviewModal(false)}
+          onSubmitted={() => loadSession(true)}
         />
       )}
     </div>

--- a/src/app/components/StudentReviewModal/StudentReviewModal.css
+++ b/src/app/components/StudentReviewModal/StudentReviewModal.css
@@ -1,0 +1,155 @@
+.student-review-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: var(--modal-backdrop);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: var(--z-modal);
+  backdrop-filter: blur(2px);
+  animation: studentReviewFadeIn var(--duration-normal) var(--ease-standard);
+}
+
+.student-review-overlay--success {
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: none;
+}
+
+.student-review-modal {
+  background: #ffffff;
+  border-radius: var(--modal-radius);
+  padding: var(--space-5) 28px;
+  width: 90%;
+  max-width: var(--modal-max-width);
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: var(--elev-modal);
+  animation: studentReviewScaleIn 0.25s var(--ease-standard);
+  text-align: center;
+}
+
+.student-review-title {
+  font-size: var(--type-body-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--calico-ink);
+  margin-bottom: var(--space-1);
+}
+
+.student-review-course {
+  font-size: var(--type-body-sm);
+  color: var(--calico-slate-700);
+  margin-bottom: var(--space-2);
+}
+
+/* Privacy hint — key to honest ratings (the student never sees this review) */
+.student-review-privacy {
+  font-size: var(--type-caption);
+  color: var(--calico-slate-700);
+  background: var(--calico-info-soft);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.student-review-block {
+  margin-bottom: var(--space-3);
+  text-align: left;
+}
+
+.student-review-name {
+  font-size: var(--type-body-sm);
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--calico-ink);
+  margin-bottom: var(--space-1);
+}
+
+.student-review-stars {
+  justify-content: center;
+}
+
+.student-review-stars button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--space-1);
+  font-size: 1.75rem;
+  display: flex;
+  align-items: center;
+  transition: transform var(--duration-normal) var(--ease-standard);
+}
+
+.student-review-stars button:hover {
+  transform: scale(1.15);
+}
+
+.student-review-stars .star-on {
+  /* same yellow as the student ReviewModal stars (Tailwind text-yellow-500) */
+  color: #eab308;
+}
+
+.student-review-stars .star-off {
+  color: var(--calico-slate-300);
+}
+
+.student-review-comment {
+  width: 100%;
+  min-height: 80px;
+  resize: none;
+  border: 1px solid var(--calico-slate-200);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  font-size: var(--type-body-sm);
+  font-family: var(--font-sans-stack);
+}
+
+.student-review-error {
+  font-size: var(--type-caption);
+  color: var(--calico-danger);
+  margin-bottom: var(--space-2);
+}
+
+.student-review-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.student-review-success-title {
+  font-size: var(--type-body-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--calico-ink);
+  margin: 0;
+}
+
+.student-review-success-img {
+  width: 220px;
+  height: auto;
+  display: block;
+  margin: var(--space-3) auto;
+}
+
+.student-review-success-message {
+  font-size: var(--type-body-sm);
+  color: var(--calico-slate-700);
+  margin: 0;
+}
+
+@keyframes studentReviewFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes studentReviewScaleIn {
+  from {
+    transform: scale(0.9);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/src/app/components/StudentReviewModal/StudentReviewModal.jsx
+++ b/src/app/components/StudentReviewModal/StudentReviewModal.jsx
@@ -1,0 +1,195 @@
+"use client";
+
+/**
+ * StudentReviewModal — tutor rates the student(s) of a completed session
+ * (reciprocal review, estilo Uber).
+ *
+ * PRIVACY: the rating + comment are never shown to the student — only the
+ * aggregate number feeds users.studentRating. The modal states this so tutors
+ * can rate honestly.
+ *
+ * Group sessions render one rating block per participant; each is submitted
+ * independently (skipped students simply stay pending).
+ */
+
+import React, { useState, useEffect, useCallback } from "react";
+import { FaStar } from "react-icons/fa";
+import { useI18n } from "../../../lib/i18n";
+import { TutoringSessionService } from "../../services/core/TutoringSessionService";
+import { Button } from "../../../components/ui/button";
+import SuccessModal from "./StudentReviewSuccess";
+import "./StudentReviewModal.css";
+
+export default function StudentReviewModal({ session, onClose, onSubmitted }) {
+  const { t } = useI18n();
+
+  const participants = session?.participants || [];
+
+  // Per-student draft state: { [studentId]: { stars, comment } }
+  const [drafts, setDrafts] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Prefill from the authoritative endpoint (covers edits after a refresh,
+  // and parents that pass a non-enriched session object).
+  useEffect(() => {
+    let cancelled = false;
+    const prefill = async () => {
+      if (!session?.id) return;
+      const seed = {};
+      const reviews = session.studentReviews?.length
+        ? session.studentReviews
+        : await TutoringSessionService.getMyStudentReviews(session.id);
+      if (cancelled) return;
+      for (const r of reviews || []) {
+        seed[r.studentId] = {
+          stars: r.rating || 0,
+          comment: r.comment || "",
+          wasDone: r.status === "done",
+        };
+      }
+      setDrafts((prev) => ({ ...seed, ...prev }));
+    };
+    prefill();
+    return () => { cancelled = true; };
+  }, [session?.id]);
+
+  const setDraft = useCallback((studentId, patch) => {
+    setDrafts((prev) => ({
+      ...prev,
+      [studentId]: { stars: 0, comment: "", ...prev[studentId], ...patch },
+    }));
+  }, []);
+
+  if (!session) return null;
+
+  const ratedCount = participants.filter((p) => (drafts[p.studentId]?.stars || 0) > 0).length;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (ratedCount === 0) {
+      setError(t("studentReview.errors.validation"));
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const toSubmit = participants.filter((p) => (drafts[p.studentId]?.stars || 0) > 0);
+      for (const p of toSubmit) {
+        const draft = drafts[p.studentId];
+        const result = await TutoringSessionService.submitStudentReview(session.id, {
+          studentId: p.studentId,
+          rating: draft.stars,
+          comment: draft.comment || undefined,
+        });
+        if (!result.success) {
+          setIsSubmitting(false);
+          setError(result.error || t("studentReview.errors.saveError"));
+          return;
+        }
+      }
+
+      setShowSuccess(true);
+      const SUCCESS_MS = 1900;
+      setTimeout(() => {
+        setShowSuccess(false);
+        if (typeof onSubmitted === "function") onSubmitted();
+        if (typeof onClose === "function") onClose();
+      }, SUCCESS_MS);
+    } catch (err) {
+      console.error("Error al guardar la calificación del estudiante:", err);
+      setIsSubmitting(false);
+      setError(t("studentReview.errors.saveError"));
+    }
+  };
+
+  const courseName =
+    (session.course && typeof session.course === "object"
+      ? session.course.name || session.course.code
+      : session.course) || t("studentReview.defaultCourse");
+
+  const singleStudent = participants.length === 1 ? participants[0]?.student : null;
+  const anyDone = participants.some((p) => drafts[p.studentId]?.wasDone);
+
+  return (
+    <>
+      {!showSuccess && (
+        <div className="student-review-overlay" onClick={onClose}>
+          <div className="student-review-modal" onClick={(e) => e.stopPropagation()}>
+            <h2 className="student-review-title">
+              {singleStudent
+                ? t("studentReview.titleSingle", { name: singleStudent.name || t("studentReview.fallbackStudent") })
+                : t("studentReview.titleGroup")}
+            </h2>
+            <p className="student-review-course">{courseName}</p>
+
+            <p className="student-review-privacy">{t("studentReview.privacyNote")}</p>
+
+            <form onSubmit={handleSubmit}>
+              {participants.map((p) => {
+                const draft = drafts[p.studentId] || { stars: 0, comment: "" };
+                return (
+                  <div key={p.studentId} className="student-review-block">
+                    {!singleStudent && (
+                      <p className="student-review-name">{p.student?.name || t("studentReview.fallbackStudent")}</p>
+                    )}
+
+                    <div className="rating-stars student-review-stars">
+                      {[1, 2, 3, 4, 5].map((n) => (
+                        <button
+                          key={n}
+                          type="button"
+                          aria-label={`${n}/5`}
+                          onClick={() => setDraft(p.studentId, { stars: n })}
+                          className={n <= draft.stars ? "star-on" : "star-off"}
+                        >
+                          <FaStar />
+                        </button>
+                      ))}
+                    </div>
+
+                    <textarea
+                      value={draft.comment}
+                      onChange={(e) => setDraft(p.studentId, { comment: e.target.value })}
+                      placeholder={t("studentReview.commentPlaceholder")}
+                      className="student-review-comment"
+                      maxLength={500}
+                    />
+                  </div>
+                );
+              })}
+
+              {error && <p className="student-review-error">{error}</p>}
+
+              <div className="student-review-actions">
+                <Button type="button" variant="outline" onClick={onClose}>
+                  {t("studentReview.buttons.close")}
+                </Button>
+                <Button type="submit" variant="tutor" disabled={ratedCount === 0 || isSubmitting}>
+                  {isSubmitting
+                    ? t("studentReview.buttons.saving")
+                    : anyDone
+                    ? t("studentReview.buttons.update")
+                    : t("studentReview.buttons.submit")}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {showSuccess && (
+        <SuccessModal
+          onClose={() => {
+            setShowSuccess(false);
+            if (typeof onSubmitted === "function") onSubmitted();
+            if (typeof onClose === "function") onClose();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/components/StudentReviewModal/StudentReviewSuccess.jsx
+++ b/src/app/components/StudentReviewModal/StudentReviewSuccess.jsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+import { useI18n } from "../../../lib/i18n";
+
+export default function StudentReviewSuccess({ onClose }) {
+  const { t } = useI18n();
+
+  return (
+    <div
+      className="student-review-overlay student-review-overlay--success"
+      onClick={onClose}
+      data-testid="student-review-success-modal"
+    >
+      <div
+        className="student-review-modal"
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="student-review-success-title">{t("studentReview.success.title")}</h3>
+
+        <img
+          src="/happy-calico.png"
+          alt=""
+          className="student-review-success-img"
+        />
+
+        <p className="student-review-success-message">{t("studentReview.success.message")}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/TutorApprovalModal/TutorApprovalModal.css
+++ b/src/app/components/TutorApprovalModal/TutorApprovalModal.css
@@ -247,6 +247,36 @@
   word-break: break-word;
 }
 
+/* Private student rating (tutor-only, estilo Uber) */
+.student-rating-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--type-xs);
+  color: var(--calico-body-muted);
+}
+
+.student-rating-star {
+  color: #eab308; /* same yellow as the review stars */
+  fill: #eab308;
+}
+
+.student-rating-line strong {
+  color: var(--calico-ink);
+}
+
+.student-rating-new {
+  align-self: flex-start;
+  font-size: 9px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background-color: var(--calico-info-soft);
+  color: var(--calico-info-text);
+  border-radius: 9999px;
+  padding: 2px var(--space-2);
+}
+
 .modal-actions {
   display: flex;
   gap: var(--space-2);

--- a/src/app/components/TutorApprovalModal/TutorApprovalModal.jsx
+++ b/src/app/components/TutorApprovalModal/TutorApprovalModal.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { X, Calendar, Clock, MapPin, User, BookOpen, MessageSquare, AlertTriangle, CheckCircle } from "lucide-react";
+import { X, Calendar, Clock, MapPin, User, BookOpen, MessageSquare, AlertTriangle, CheckCircle, Star } from "lucide-react";
 import { TutoringSessionService } from "../../services/core/TutoringSessionService";
 import SessionBookedModal from "../SessionBookedModal/SessionBookedModal";
 import "./TutorApprovalModal.css";
@@ -68,7 +68,20 @@ export default function TutorApprovalModal({
     }
   };
 
-  const { date, time } = formatDateTime(session.scheduledStart);
+  const { date, time } = formatDateTime(session.scheduledStart || session.startTimestamp);
+
+  // The session may arrive flattened (legacy callers) or as the raw API shape
+  // (participants[].student). Support both; the API shape also carries the
+  // private student rating for tutor payloads (estilo Uber).
+  const participantStudent = session.participants?.[0]?.student;
+  const studentName =
+    session.studentName || participantStudent?.name || session.studentEmail || participantStudent?.email || 'Estudiante';
+  const courseName =
+    session.course && typeof session.course === 'object'
+      ? session.course.name || session.course.code
+      : session.course;
+  const ratingCount = participantStudent?.studentRatingCount;
+  const ratingAvg = Number(participantStudent?.studentRating) || 0;
 
   return (
     <div className="tutor-approval-modal-overlay">
@@ -112,7 +125,19 @@ export default function TutorApprovalModal({
                 <User className="info-icon" size={16} />
                 <div className="info-content">
                   <span className="info-label">Estudiante</span>
-                  <span className="info-value">{session.studentName || session.studentEmail}</span>
+                  <span className="info-value">{studentName}</span>
+                  {/* Private student rating (visible to tutors only) */}
+                  {ratingCount > 0 ? (
+                    <span className="student-rating-line">
+                      <Star size={13} className="student-rating-star" />
+                      <strong>{ratingAvg.toFixed(1)}</strong>
+                      <span className="student-rating-count">
+                        · {ratingCount} {ratingCount === 1 ? 'calificación' : 'calificaciones'}
+                      </span>
+                    </span>
+                  ) : ratingCount === 0 ? (
+                    <span className="student-rating-new">Nuevo</span>
+                  ) : null}
                 </div>
               </div>
 
@@ -120,7 +145,7 @@ export default function TutorApprovalModal({
                 <BookOpen className="info-icon" size={16} />
                 <div className="info-content">
                   <span className="info-label">Materia</span>
-                  <span className="info-value">{session.course}</span>
+                  <span className="info-value">{courseName}</span>
                 </div>
               </div>
 
@@ -190,12 +215,12 @@ export default function TutorApprovalModal({
             onClose(); // Close the main approval modal after confirmation
           }}
           sessionData={{
-            tutorName: session.tutorName || 'Tutor',
-            studentName: session.studentName || session.studentEmail,
-            studentEmail: session.studentEmail,
-            course: session.course,
-            scheduledStart: session.scheduledStart,
-            endDateTime: session.endDateTime,
+            tutorName: session.tutorName || session.tutor?.name || 'Tutor',
+            studentName,
+            studentEmail: session.studentEmail || participantStudent?.email,
+            course: courseName,
+            scheduledStart: session.scheduledStart || session.startTimestamp,
+            endDateTime: session.endDateTime || session.endTimestamp,
             location: session.location
           }}
           userType="tutor"

--- a/src/app/home/admin/users/[userId]/page.jsx
+++ b/src/app/home/admin/users/[userId]/page.jsx
@@ -67,6 +67,42 @@ function SessionItem({ s, counterpart, formatDate, t }) {
   );
 }
 
+/**
+ * One reviews-received list (works for both directions):
+ *  - as tutor:   public student→tutor reviews (reviewer = r.student)
+ *  - as student: private tutor→student reviews (reviewer = r.tutor)
+ */
+function ReviewListSection({ title, subtitle, reviews, reviewerOf, starTone, formatDate }) {
+  return (
+    <section className="bg-white rounded-2xl border border-gray-100 p-5">
+      <h3 className="text-sm font-semibold text-gray-800 mb-1">
+        {title} <span className="text-gray-400 font-normal">({reviews.length})</span>
+      </h3>
+      {subtitle && <p className="text-xs text-gray-400 mb-3">{subtitle}</p>}
+      <ul className="flex flex-col gap-2">
+        {reviews.map((r) => {
+          const reviewer = reviewerOf(r);
+          return (
+            <li key={r.id} className="border border-gray-100 rounded-xl p-3">
+              <div className="flex items-center justify-between gap-2 flex-wrap">
+                <span className="text-sm font-medium text-gray-800 truncate">{reviewer?.name || '—'}</span>
+                <span className="inline-flex items-center gap-1 text-sm font-semibold text-gray-900">
+                  <Star className={`w-3.5 h-3.5 ${starTone}`} /> {r.rating ?? '—'}
+                </span>
+              </div>
+              <div className="text-[11px] text-gray-400 mt-0.5">
+                {r.session?.course?.name || r.course?.name || ''}
+                {r.session?.startTimestamp ? ` · ${formatDate(r.session.startTimestamp)}` : ''}
+              </div>
+              {r.comment && <p className="text-sm text-gray-600 mt-1.5 whitespace-pre-line break-words">{r.comment}</p>}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
 export default function AdminUserDetailPage() {
   const router = useRouter();
   const params = useParams();
@@ -201,14 +237,29 @@ export default function AdminUserDetailPage() {
             {tp?.bio && <p className="text-sm text-gray-600 mt-3 whitespace-pre-line">{tp.bio}</p>}
           </div>
 
-          {isTutor && tp?.review != null && Number(tp.review) > 0 && (
-            <div className="flex flex-col items-end gap-0.5 flex-shrink-0">
-              <span className="inline-flex items-center gap-1 text-lg font-bold text-gray-900">
-                <Star className="w-4 h-4 text-amber-500 fill-amber-500" /> {Number(tp.review).toFixed(2)}
-              </span>
-              <span className="text-[11px] text-gray-400">
-                {t(asTutor.reviewsReceived === 1 ? 'admin.users.detail.reviews_one' : 'admin.users.detail.reviews_other', { count: asTutor.reviewsReceived })}
-              </span>
+          {/* Ratings on BOTH sides of the marketplace, side by side */}
+          {((isTutor && tp?.review != null && Number(tp.review) > 0) || u.studentRatingCount > 0) && (
+            <div className="flex sm:flex-col items-start sm:items-end gap-3 sm:gap-2 flex-shrink-0 flex-wrap">
+              {isTutor && tp?.review != null && Number(tp.review) > 0 && (
+                <div className="flex flex-col items-start sm:items-end gap-0.5">
+                  <span className="inline-flex items-center gap-1 text-lg font-bold text-gray-900">
+                    <Star className="w-4 h-4 text-amber-500 fill-amber-500" /> {Number(tp.review).toFixed(2)}
+                  </span>
+                  <span className="text-[11px] text-gray-400">
+                    {t('admin.users.detail.ratingAsTutor')} · {t(asTutor.reviewsReceived === 1 ? 'admin.users.detail.reviews_one' : 'admin.users.detail.reviews_other', { count: asTutor.reviewsReceived })}
+                  </span>
+                </div>
+              )}
+              {u.studentRatingCount > 0 && (
+                <div className="flex flex-col items-start sm:items-end gap-0.5">
+                  <span className="inline-flex items-center gap-1 text-lg font-bold text-gray-900">
+                    <Star className="w-4 h-4 text-sky-500 fill-sky-500" /> {Number(u.studentRating).toFixed(2)}
+                  </span>
+                  <span className="text-[11px] text-gray-400">
+                    {t('admin.users.detail.ratingAsStudent')} · {t(u.studentRatingCount === 1 ? 'admin.users.detail.reviews_one' : 'admin.users.detail.reviews_other', { count: u.studentRatingCount })}
+                  </span>
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -237,6 +288,12 @@ export default function AdminUserDetailPage() {
             <StatItem icon={UsersIcon} label={t('admin.users.detail.stat.distinctTutors')} value={asStudent.distinctTutors} />
             <StatItem icon={BookOpen} label={t('admin.users.detail.stat.distinctCourses')} value={asStudent.distinctCourses} />
             <StatItem icon={DollarSign} tone="text-orange-500" label={t('admin.users.detail.stat.spent')} value={formatCurrency(asStudent.spent, 'COP')} />
+            <StatItem
+              icon={Star}
+              tone="text-amber-500"
+              label={t('admin.users.detail.stat.studentRating')}
+              value={asStudent.ratingCount > 0 ? `${Number(asStudent.rating).toFixed(2)} (${asStudent.ratingCount})` : '—'}
+            />
           </div>
         </section>
 
@@ -280,6 +337,36 @@ export default function AdminUserDetailPage() {
             ))}
           </div>
         </section>
+      )}
+
+      {/* ── Reviews received on BOTH sides (behaviour as tutor AND as student) ── */}
+      {((data.tutorReviewsReceived?.length || 0) > 0 || (data.studentReviewsReceived?.length || 0) > 0) && (
+        <div className={`grid grid-cols-1 ${
+          (data.tutorReviewsReceived?.length || 0) > 0 && (data.studentReviewsReceived?.length || 0) > 0
+            ? 'lg:grid-cols-2'
+            : ''
+        } gap-3`}>
+          {(data.tutorReviewsReceived?.length || 0) > 0 && (
+            <ReviewListSection
+              title={t('admin.users.detail.tutorReviews.title')}
+              subtitle={t('admin.users.detail.tutorReviews.publicNote')}
+              reviews={data.tutorReviewsReceived}
+              reviewerOf={(r) => r.student}
+              starTone="text-amber-500 fill-amber-500"
+              formatDate={formatDate}
+            />
+          )}
+          {(data.studentReviewsReceived?.length || 0) > 0 && (
+            <ReviewListSection
+              title={t('admin.users.detail.studentReviews.title')}
+              subtitle={t('admin.users.detail.studentReviews.privacy')}
+              reviews={data.studentReviewsReceived}
+              reviewerOf={(r) => r.tutor}
+              starTone="text-sky-500 fill-sky-500"
+              formatDate={formatDate}
+            />
+          )}
+        </div>
       )}
 
       {/* ── Recent sessions ───────────────────────────────────────── */}

--- a/src/app/home/admin/users/page.jsx
+++ b/src/app/home/admin/users/page.jsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Search, ArrowRight, Star, ShieldCheck, GraduationCap, AlertOctagon } from 'lucide-react';
+import { Search, ArrowRight, ArrowUpDown, Star, ShieldCheck, GraduationCap, AlertOctagon } from 'lucide-react';
 import { AdminService } from '../../../services/core/AdminService';
 import routes from '../../../../routes';
 import { useI18n } from '../../../../lib/i18n';
@@ -13,6 +13,17 @@ const TABS = [
   { key: 'tutors',    i18nKey: 'admin.users.tabs.tutors' },
   { key: 'admins',    i18nKey: 'admin.users.tabs.admins' },
   { key: 'suspended', i18nKey: 'admin.users.tabs.suspended' },
+];
+
+// Mirrors LIST_SORTS in admin-users.service. The rating sorts only list
+// users that have ratings on that side (new users are excluded so "worst
+// rated" isn't polluted by 0-review defaults).
+const SORTS = [
+  { key: 'recent',       i18nKey: 'admin.users.sort.recent' },
+  { key: 'tutorBest',    i18nKey: 'admin.users.sort.tutorBest' },
+  { key: 'tutorWorst',   i18nKey: 'admin.users.sort.tutorWorst' },
+  { key: 'studentBest',  i18nKey: 'admin.users.sort.studentBest' },
+  { key: 'studentWorst', i18nKey: 'admin.users.sort.studentWorst' },
 ];
 
 function initials(name) {
@@ -52,7 +63,8 @@ function RoleBadges({ u, t }) {
 
 function UserRow({ u, t }) {
   const tp = u.tutorProfile;
-  const rating = tp?.review && Number(tp.review) > 0 ? Number(tp.review).toFixed(2) : null;
+  const tutorRating = tp?.review && Number(tp.review) > 0 ? Number(tp.review).toFixed(2) : null;
+  const studentRating = u.studentRatingCount > 0 ? Number(u.studentRating).toFixed(2) : null;
   return (
     <Link
       href={routes.ADMIN_USER_DETAIL(u.id)}
@@ -76,10 +88,16 @@ function UserRow({ u, t }) {
                 <GraduationCap className="w-3 h-3" /> {u.career.name}
               </span>
             )}
-            {rating && (
+            {tutorRating && (
               <span className="inline-flex items-center gap-1 text-gray-500">
-                <Star className="w-3 h-3 text-amber-500 fill-amber-500" /> {rating}
-                <span className="text-gray-400">({tp.numReview})</span>
+                <Star className="w-3 h-3 text-amber-500 fill-amber-500" /> {tutorRating}
+                <span className="text-gray-400">({tp.numReview}) · {t('admin.users.row.asTutor')}</span>
+              </span>
+            )}
+            {studentRating && (
+              <span className="inline-flex items-center gap-1 text-gray-500">
+                <Star className="w-3 h-3 text-sky-500 fill-sky-500" /> {studentRating}
+                <span className="text-gray-400">({u.studentRatingCount}) · {t('admin.users.row.asStudent')}</span>
               </span>
             )}
           </div>
@@ -95,6 +113,7 @@ export default function AdminUsersPage() {
   const { t } = useI18n();
   const [activeTab, setActiveTab] = useState('all');
   const [search, setSearch] = useState('');
+  const [sort, setSort] = useState('recent');
   const [items, setItems] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -114,6 +133,7 @@ export default function AdminUsersPage() {
       const res = await AdminService.listUsers({
         role: activeTab,
         search: debouncedSearch || undefined,
+        sort,
         limit: 100,
       });
       if (!res.success) throw new Error(res.error || t('admin.users.loadError'));
@@ -126,7 +146,7 @@ export default function AdminUsersPage() {
     } finally {
       setLoading(false);
     }
-  }, [activeTab, debouncedSearch, t]);
+  }, [activeTab, debouncedSearch, sort, t]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
@@ -155,22 +175,40 @@ export default function AdminUsersPage() {
         ))}
       </div>
 
-      {/* Search */}
-      <div className="relative max-w-md">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder={t('admin.users.search')}
-          className="w-full pl-9 pr-3 py-2 bg-white border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-400"
-        />
+      {/* Search + sort */}
+      <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('admin.users.search')}
+            className="w-full pl-9 pr-3 py-2 bg-white border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-400"
+          />
+        </div>
+        <div className="relative sm:w-64">
+          <ArrowUpDown className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value)}
+            aria-label={t('admin.users.sort.label')}
+            className="w-full appearance-none pl-9 pr-8 py-2 bg-white border border-gray-200 rounded-xl text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-400 cursor-pointer"
+          >
+            {SORTS.map(({ key, i18nKey }) => (
+              <option key={key} value={key}>{t(i18nKey)}</option>
+            ))}
+          </select>
+        </div>
       </div>
 
-      {/* Counter */}
+      {/* Counter (+ hint when a rating sort hides unrated users) */}
       {!loading && !error && (
         <p className="text-xs text-gray-500 -mt-1">
           {t(total === 1 ? 'admin.users.results_one' : 'admin.users.results_other', { count: total })}
+          {sort !== 'recent' && (
+            <span className="text-gray-400"> · {t('admin.users.sort.onlyRated')}</span>
+          )}
         </p>
       )}
 

--- a/src/app/home/profile/page.jsx
+++ b/src/app/home/profile/page.jsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { Edit3, Shield, Lock, Eye, EyeOff, Settings, LogOut, X, GraduationCap, Clock, ArrowRight, Calendar, BookOpen, Camera, Trash2, Loader2 } from 'lucide-react';
+import { Edit3, Shield, Lock, Eye, EyeOff, Settings, LogOut, X, GraduationCap, Clock, ArrowRight, Calendar, BookOpen, Camera, Trash2, Loader2, Star } from 'lucide-react';
 import Link from 'next/link';
 import routes from '../../../routes';
 import { useAuth } from '../../context/SecureAuthContext';
@@ -526,6 +526,7 @@ const Profile = () => {
   const [passwordModalOpen, setPasswordModalOpen] = useState(false);
   const [studentSessions, setStudentSessions] = useState([]);
   const [studentSessionsLoading, setStudentSessionsLoading] = useState(true);
+  const [myStudentRating, setMyStudentRating] = useState(null);
   // Re-scan once the user resolves and the role swap remounts the cards.
   // `studentSessionsLoading` is in the deps so the observer re-scans once the
   // student fetch resolves — the "subjects chips" card is conditional on
@@ -562,6 +563,16 @@ const Profile = () => {
       })
       .catch(() => { if (!cancelled) setStudentSessions([]); })
       .finally(() => { if (!cancelled) setStudentSessionsLoading(false); });
+    return () => { cancelled = true; };
+  }, [user?.uid, activeRole]);
+
+  // Own rating as a student (tutor→student reviews; number only, never comments)
+  useEffect(() => {
+    if (!user?.uid || activeRole !== 'student') return;
+    let cancelled = false;
+    TutoringSessionService.getMyStudentRating()
+      .then((rating) => { if (!cancelled) setMyStudentRating(rating); })
+      .catch(() => { if (!cancelled) setMyStudentRating(null); });
     return () => { cancelled = true; };
   }, [user?.uid, activeRole]);
 
@@ -776,7 +787,7 @@ const Profile = () => {
 
             {/* Student-only: stats row */}
             {activeRole === 'student' && (
-              <div className="grid grid-cols-3 gap-3" data-reveal style={{ transitionDelay: '0.08s' }}>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-reveal style={{ transitionDelay: '0.08s' }}>
                 <StatCard
                   icon={GraduationCap}
                   value={studentSessionsLoading ? '—' : studentDerived.sessionsTaken}
@@ -791,6 +802,11 @@ const Profile = () => {
                   icon={BookOpen}
                   value={studentSessionsLoading ? '—' : studentDerived.subjects.length}
                   label={t('profile.stats.subjects')}
+                />
+                <StatCard
+                  icon={Star}
+                  value={myStudentRating && myStudentRating.count > 0 ? myStudentRating.average.toFixed(1) : '—'}
+                  label={t('profile.stats.myRating')}
                 />
               </div>
             )}

--- a/src/app/services/core/AdminService.js
+++ b/src/app/services/core/AdminService.js
@@ -38,8 +38,8 @@ class AdminServiceClass {
 
   // ─── Users directory ──────────────────────────────────────────────────
 
-  async listUsers({ role = 'all', search, limit = 50, offset = 0 } = {}) {
-    const params = new URLSearchParams({ role, limit: String(limit), offset: String(offset) });
+  async listUsers({ role = 'all', search, sort = 'recent', limit = 50, offset = 0 } = {}) {
+    const params = new URLSearchParams({ role, sort, limit: String(limit), offset: String(offset) });
     if (search) params.set('search', search);
     const { ok, status, data } = await authFetch(`${BASE}/users?${params}`);
     return { ok, status, ...(data || {}) };

--- a/src/app/services/core/TutoringSessionService.js
+++ b/src/app/services/core/TutoringSessionService.js
@@ -191,6 +191,52 @@ class TutoringSessionServiceClass {
     console.error('Error submitting review:', errorMsg);
     return { success: false, review: null, updated: false, error: errorMsg };
   }
+
+  /**
+   * Submit (or edit) a tutor→student review for a finished session (tutor action).
+   * @param {string} sessionId
+   * @param {{ studentId: string, rating: number, comment?: string }} reviewData
+   * @returns {Promise<{ success: boolean, review: Object|null, updated: boolean, error?: string }>}
+   */
+  async submitStudentReview(sessionId, reviewData) {
+    const { ok, data } = await authFetch(`${API_BASE_URL}/sessions/${sessionId}/student-reviews`, {
+      method: 'POST',
+      body: JSON.stringify(reviewData),
+    });
+
+    if (ok && data?.success) {
+      return {
+        success: true,
+        review: data.review || null,
+        updated: data.updated || false,
+      };
+    }
+
+    const errorMsg = data?.error || 'Failed to submit student review';
+    console.error('Error submitting student review:', errorMsg);
+    return { success: false, review: null, updated: false, error: errorMsg };
+  }
+
+  /**
+   * Reviews the authenticated tutor wrote for a session (pending + done) —
+   * powers the rate-students modal prefill.
+   * @returns {Promise<Array>}
+   */
+  async getMyStudentReviews(sessionId) {
+    const { ok, data } = await authFetch(`${API_BASE_URL}/sessions/${sessionId}/student-reviews`);
+    if (ok && data?.success) return data.reviews || [];
+    return [];
+  }
+
+  /**
+   * The caller's own aggregate rating as a student (number only).
+   * @returns {Promise<{ average: number, count: number }|null>}
+   */
+  async getMyStudentRating() {
+    const { ok, data } = await authFetch(`${API_BASE_URL}/users/me/student-rating`);
+    if (ok && data?.success) return { average: data.average ?? 0, count: data.count ?? 0 };
+    return null;
+  }
 }
 
 // Export singleton instance

--- a/src/lib/auth/guards.js
+++ b/src/lib/auth/guards.js
@@ -90,6 +90,26 @@ export async function requireAdminUser(request) {
 }
 
 /**
+ * Lightweight role check: does this user have `role = 'ADMIN'` in the DB?
+ *
+ * Use when a route is owner-scoped but should ALSO allow admins through
+ * (e.g. "the tutor themselves OR an admin may read these payments"). Returns
+ * a plain boolean — unlike {@link requireAdminUser}, it does not short-circuit
+ * with a NextResponse, so the caller can fall back to its own owner check.
+ *
+ * @param {string} userId
+ * @returns {Promise<boolean>}
+ */
+export async function isAdmin(userId) {
+  if (!userId) return false;
+  const user = await prisma.user.findUnique({
+    where: { id: String(userId) },
+    select: { role: true, isActive: true },
+  });
+  return Boolean(user && user.isActive && user.role === 'ADMIN');
+}
+
+/**
  * Authenticate the request AND verify the user is an approved tutor.
  * Returns the decoded JWT payload on success, or a NextResponse error.
  *

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -597,7 +597,8 @@
     "stats": {
       "sessionsTaken": "Sessions taken",
       "hoursStudied": "Hours studied",
-      "subjects": "Subjects"
+      "subjects": "Subjects",
+      "myRating": "My rating"
     },
     "nextSession": {
       "title": "Next session",
@@ -931,6 +932,7 @@
       "pendingSessionRequest": "Tutoring Request",
       "sessionConfirmed": "Tutoring Confirmed",
       "sessionReminder": "Session Reminder",
+      "studentReviewReminder": "Rate your student",
       "message": "Message"
     },
     "student": {
@@ -978,6 +980,35 @@
       "authRequired": "You must be logged in to submit a review.",
       "sessionNotFound": "The session does not exist.",
       "saveError": "Error saving the review."
+    }
+  },
+  "studentReview": {
+    "titleSingle": "How was your session with {name}?",
+    "titleGroup": "Rate your students",
+    "defaultCourse": "Tutoring session",
+    "fallbackStudent": "Student",
+    "privacyNote": "Your rating is private: the student will never see the stars or your comment. It only feeds their overall average, visible to other tutors.",
+    "commentPlaceholder": "Private comment for Calico (optional)",
+    "buttons": {
+      "submit": "Submit rating",
+      "update": "Update rating",
+      "saving": "Saving...",
+      "close": "Close"
+    },
+    "errors": {
+      "validation": "Select at least 1 star.",
+      "saveError": "Error saving the rating."
+    },
+    "success": {
+      "title": "Rating submitted!",
+      "message": "Thanks for helping the Calico tutor community."
+    },
+    "ownRating": {
+      "title": "Your rating as a student",
+      "description": "Average of the ratings tutors have given you. Only you and your tutors can see it.",
+      "new": "No ratings yet",
+      "count_one": "{count} rating",
+      "count_other": "{count} ratings"
     }
   },
   "successModal": {
@@ -2314,6 +2345,19 @@
       "results_other": "{count} users",
       "loadError": "Failed to load users",
       "empty": "No users match.",
+      "sort": {
+        "label": "Sort by",
+        "recent": "Most recent",
+        "tutorBest": "Best rated (tutor)",
+        "tutorWorst": "Worst rated (tutor)",
+        "studentBest": "Best rated (student)",
+        "studentWorst": "Worst rated (student)",
+        "onlyRated": "only users with ratings"
+      },
+      "row": {
+        "asTutor": "as tutor",
+        "asStudent": "as student"
+      },
       "badge": {
         "admin": "Admin",
         "tutor": "Tutor",
@@ -2338,6 +2382,8 @@
         "suspendedReason": "Suspension reason",
         "reviews_one": "{count} review received",
         "reviews_other": "{count} reviews received",
+        "ratingAsTutor": "As tutor",
+        "ratingAsStudent": "As student",
         "activity": {
           "title": "Monthly activity",
           "subtitle": "Completed sessions per month, last 12 months.",
@@ -2358,7 +2404,16 @@
           "spent": "Total spent",
           "earned": "Total earned (85%)",
           "earnedPending": "Pending payout",
-          "nextPayment": "Next payment"
+          "nextPayment": "Next payment",
+          "studentRating": "Rating from tutors"
+        },
+        "studentReviews": {
+          "title": "Ratings received from tutors",
+          "privacy": "Private: the student and other users never see these comments — Calico staff only."
+        },
+        "tutorReviews": {
+          "title": "Reviews received from students",
+          "publicNote": "Public: shown on the tutor's profile."
         },
         "tutorOf": { "title": "Tutors" },
         "recentAsStudent": "Recent sessions (student)",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -598,7 +598,8 @@
     "stats": {
       "sessionsTaken": "Tutorías tomadas",
       "hoursStudied": "Horas estudiadas",
-      "subjects": "Materias"
+      "subjects": "Materias",
+      "myRating": "Mi calificación"
     },
     "nextSession": {
       "title": "Próxima tutoría",
@@ -931,6 +932,7 @@
       "pendingSessionRequest": "Solicitud de Tutoría",
       "sessionConfirmed": "Tutoría Confirmada",
       "sessionReminder": "Recordatorio de Sesión",
+      "studentReviewReminder": "Califica a tu estudiante",
       "message": "Mensaje"
     },
     "student": {
@@ -980,6 +982,36 @@
       "saveError": "Error al guardar la reseña."
   }
 },
+
+  "studentReview": {
+    "titleSingle": "¿Cómo te fue con {name}?",
+    "titleGroup": "Califica a tus estudiantes",
+    "defaultCourse": "Tutoría",
+    "fallbackStudent": "Estudiante",
+    "privacyNote": "Tu calificación es privada: el estudiante no verá ni las estrellas ni tu comentario. Solo alimenta su promedio general, visible para otros tutores.",
+    "commentPlaceholder": "Comentario privado para Calico (opcional)",
+    "buttons": {
+      "submit": "Enviar calificación",
+      "update": "Actualizar calificación",
+      "saving": "Guardando...",
+      "close": "Cerrar"
+    },
+    "errors": {
+      "validation": "Selecciona al menos 1 estrella.",
+      "saveError": "Error al guardar la calificación."
+    },
+    "success": {
+      "title": "¡Calificación enviada!",
+      "message": "Gracias por ayudar a la comunidad de tutores de Calico."
+    },
+    "ownRating": {
+      "title": "Tu calificación como estudiante",
+      "description": "Promedio de las calificaciones que los tutores te han dado. Solo tú y tus tutores pueden verlo.",
+      "new": "Aún no tienes calificaciones",
+      "count_one": "{count} calificación",
+      "count_other": "{count} calificaciones"
+    }
+  },
 
   "successModal": {
     "title": "¡Reseña enviada con éxito!",
@@ -2323,6 +2355,19 @@
       "results_other": "{count} usuarios",
       "loadError": "Error cargando usuarios",
       "empty": "No hay usuarios que coincidan.",
+      "sort": {
+        "label": "Ordenar por",
+        "recent": "Más recientes",
+        "tutorBest": "Mejor calificados (tutor)",
+        "tutorWorst": "Peor calificados (tutor)",
+        "studentBest": "Mejor calificados (estudiante)",
+        "studentWorst": "Peor calificados (estudiante)",
+        "onlyRated": "solo usuarios con calificaciones"
+      },
+      "row": {
+        "asTutor": "como tutor",
+        "asStudent": "como estudiante"
+      },
       "badge": {
         "admin": "Admin",
         "tutor": "Tutor",
@@ -2347,6 +2392,8 @@
         "suspendedReason": "Motivo de suspensión",
         "reviews_one": "{count} reseña recibida",
         "reviews_other": "{count} reseñas recibidas",
+        "ratingAsTutor": "Como tutor",
+        "ratingAsStudent": "Como estudiante",
         "activity": {
           "title": "Actividad mensual",
           "subtitle": "Sesiones completadas por mes, últimos 12 meses.",
@@ -2367,7 +2414,16 @@
           "spent": "Total gastado",
           "earned": "Total ganado (85%)",
           "earnedPending": "Por transferir",
-          "nextPayment": "Próximo pago"
+          "nextPayment": "Próximo pago",
+          "studentRating": "Calificación de tutores"
+        },
+        "studentReviews": {
+          "title": "Calificaciones recibidas de tutores",
+          "privacy": "Privadas: el estudiante y otros usuarios nunca ven estos comentarios — solo el equipo de Calico."
+        },
+        "tutorReviews": {
+          "title": "Reseñas recibidas de estudiantes",
+          "publicNote": "Públicas: aparecen en el perfil del tutor."
         },
         "tutorOf": { "title": "Tutor de" },
         "recentAsStudent": "Sesiones recientes (estudiante)",

--- a/src/lib/repositories/student-review.repository.js
+++ b/src/lib/repositories/student-review.repository.js
@@ -1,0 +1,197 @@
+/**
+ * Student Review Repository
+ * Handles database operations for tutor→student reviews (PostgreSQL via Prisma).
+ *
+ * Model: StudentReview (tutorId = reviewer, studentId = reviewee, tied to a Session).
+ * PRIVACY: these reviews are never public. The aggregate lives denormalized on
+ * users.student_rating / users.student_rating_count (stripped from generic user
+ * fetches by user.repository sanitize) and is only attached to tutor-facing
+ * session payloads, the owner's own-rating endpoint, and admin views.
+ */
+
+import prisma from '../prisma';
+
+export async function findById(id) {
+  return prisma.studentReview.findUnique({
+    where: { id },
+    include: {
+      tutor: { select: { id: true, name: true, profilePictureUrl: true } },
+      student: { select: { id: true, name: true, profilePictureUrl: true } },
+    },
+  });
+}
+
+/**
+ * All student reviews for a session (admin / internal use — includes comments).
+ */
+export async function findBySession(sessionId) {
+  return prisma.studentReview.findMany({
+    where: { sessionId },
+    include: {
+      tutor: { select: { id: true, name: true, profilePictureUrl: true } },
+      student: { select: { id: true, name: true, profilePictureUrl: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+/**
+ * Reviews written by a tutor for one session (edit prefill / pending state).
+ * Safe to return to that tutor: they authored them.
+ */
+export async function findBySessionForTutor(sessionId, tutorId) {
+  return prisma.studentReview.findMany({
+    where: { sessionId, tutorId },
+    orderBy: { createdAt: 'asc' },
+  });
+}
+
+/**
+ * Batch variant for tutor session lists: all reviews this tutor wrote across
+ * many sessions, in a single query. Returns a Map keyed by sessionId.
+ */
+export async function findBySessionIdsForTutor(sessionIds, tutorId) {
+  const map = new Map();
+  if (!sessionIds || sessionIds.length === 0) return map;
+  const rows = await prisma.studentReview.findMany({
+    where: { sessionId: { in: sessionIds }, tutorId },
+    orderBy: { createdAt: 'asc' },
+  });
+  for (const r of rows) {
+    if (!map.has(r.sessionId)) map.set(r.sessionId, []);
+    map.get(r.sessionId).push(r);
+  }
+  return map;
+}
+
+/**
+ * Reviews received by a student (admin moderation view — includes comments,
+ * tutor identity and session course).
+ */
+export async function findReceivedByStudent(studentId, limit = 50) {
+  return prisma.studentReview.findMany({
+    where: { studentId, status: 'done' },
+    include: {
+      tutor: { select: { id: true, name: true, profilePictureUrl: true } },
+      session: { select: { id: true, startTimestamp: true, course: { select: { id: true, name: true, code: true } } } },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  });
+}
+
+/**
+ * Create or update a tutor→student review. Unlike the legacy reviews table,
+ * student_reviews was born with its compound unique constraint, so we can use
+ * Prisma's native atomic upsert.
+ */
+export async function upsertStudentReview({ sessionId, tutorId, studentId, rating, status, comment }) {
+  return prisma.studentReview.upsert({
+    where: {
+      sessionId_tutorId_studentId: { sessionId, tutorId, studentId },
+    },
+    update: {
+      rating: rating ?? undefined,
+      status: status ?? undefined,
+      comment: comment ?? undefined,
+    },
+    create: {
+      sessionId,
+      tutorId,
+      studentId,
+      rating: rating ?? null,
+      status: status ?? 'pending',
+      comment: comment ?? null,
+    },
+    include: {
+      student: { select: { id: true, name: true, profilePictureUrl: true } },
+    },
+  });
+}
+
+/**
+ * Create a pending placeholder (null rating) — used by completeSession.
+ * Idempotent: if a row already exists it is left untouched (update with all
+ * undefined fields is a no-op write of the same values).
+ */
+export async function createPendingStudentReview(sessionId, tutorId, studentId) {
+  return prisma.studentReview.upsert({
+    where: {
+      sessionId_tutorId_studentId: { sessionId, tutorId, studentId },
+    },
+    update: {},
+    create: { sessionId, tutorId, studentId, rating: null, status: 'pending', comment: null },
+  });
+}
+
+/**
+ * Recompute the student's denormalized aggregate (users.student_rating /
+ * student_rating_count) from scratch inside a transaction — same proven
+ * pattern as review.repository.updateTutorReviewStats, so edits stay
+ * consistent under concurrency.
+ */
+export async function updateStudentRatingStats(studentId) {
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const reviews = await tx.studentReview.findMany({
+        where: { studentId, status: 'done', rating: { not: null } },
+        select: { rating: true },
+      });
+
+      let newAverage = 0;
+      const newCount = reviews.length;
+      if (newCount > 0) {
+        const total = reviews.reduce((sum, r) => sum + (Number(r.rating) || 0), 0);
+        newAverage = Math.round((total / newCount) * 100) / 100;
+      }
+
+      return tx.user.update({
+        where: { id: studentId },
+        data: {
+          studentRating: newAverage,
+          studentRatingCount: newCount,
+        },
+        select: { id: true, studentRating: true, studentRatingCount: true },
+      });
+    });
+  } catch (err) {
+    console.error(`[StudentReview] Error updating student stats for ${studentId}:`, err.message);
+    throw err;
+  }
+}
+
+/**
+ * Denormalized aggregate for one user — used for the owner's own-rating
+ * endpoint. Returns { average, count }.
+ */
+export async function getStudentRating(userId) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { studentRating: true, studentRatingCount: true },
+  });
+  if (!user) return null;
+  return {
+    average: Number(user.studentRating) || 0,
+    count: user.studentRatingCount || 0,
+  };
+}
+
+/**
+ * Batch read of denormalized aggregates for many students in one query.
+ * Used to enrich tutor-facing session payloads. Returns a Map keyed by userId.
+ */
+export async function getStudentRatingsMap(studentIds) {
+  const map = new Map();
+  if (!studentIds || studentIds.length === 0) return map;
+  const rows = await prisma.user.findMany({
+    where: { id: { in: studentIds } },
+    select: { id: true, studentRating: true, studentRatingCount: true },
+  });
+  for (const u of rows) {
+    map.set(u.id, {
+      average: Number(u.studentRating) || 0,
+      count: u.studentRatingCount || 0,
+    });
+  }
+  return map;
+}

--- a/src/lib/repositories/user.repository.js
+++ b/src/lib/repositories/user.repository.js
@@ -8,17 +8,30 @@ import prisma from '../prisma';
 // Fields to never return to the client
 const SENSITIVE_FIELDS = ['passwordHash', 'verificationToken', 'resetToken', 'resetTokenExpiry', 'otpCode', 'otpCodeExpiry'];
 
+// Private-by-default fields: stripped from every generic user fetch so they
+// never leak through /api/users/:id or /api/auth/me. The student rating
+// (tutor → estudiante, estilo Uber) is only exposed deliberately:
+//   - to tutors, attached to their session payloads (session.service)
+//   - to the owner, via GET /api/users/me/student-rating (number only)
+//   - to admins, via admin-users.service explicit selects
+const PRIVATE_FIELDS = ['studentRating', 'studentRatingCount'];
+
 /**
  * Strip sensitive fields from a user object.
+ * Exported as `sanitizeUser` for routes that must work with a raw Prisma user
+ * (e.g. login needs passwordHash to compare) and then sanitize the response
+ * themselves — so there is exactly ONE strip list in the codebase.
  */
 function sanitize(user) {
   if (!user) return null;
   const clean = { ...user };
-  for (const field of SENSITIVE_FIELDS) {
+  for (const field of [...SENSITIVE_FIELDS, ...PRIVATE_FIELDS]) {
     delete clean[field];
   }
   return clean;
 }
+
+export { sanitize as sanitizeUser };
 
 /**
  * Find user by ID (public-safe — no password hash)
@@ -93,6 +106,20 @@ export async function findByEmail(email) {
 export async function findByEmailWithPassword(email) {
   return prisma.user.findUnique({
     where: { email },
+  });
+}
+
+/**
+ * Fetch the OTP verification state for a user by email. Returns the raw
+ * (un-sanitized) OTP fields — which the generic `findByEmail` strips — so the
+ * password-reset OTP flow can compare the code and enforce its attempt counter.
+ * @param {string} email
+ * @returns {Promise<{ id: string, otpCode: string|null, otpCodeExpiry: Date|null, otpAttempts: number }|null>}
+ */
+export async function findOtpStateByEmail(email) {
+  return prisma.user.findUnique({
+    where: { email },
+    select: { id: true, otpCode: true, otpCodeExpiry: true, otpAttempts: true },
   });
 }
 

--- a/src/lib/services/admin-users.service.js
+++ b/src/lib/services/admin-users.service.js
@@ -14,9 +14,14 @@
 
 import prisma from '../prisma';
 import * as statsRepo from '../repositories/admin-users.repository';
+import * as studentReviewRepo from '../repositories/student-review.repository';
+import * as reviewRepo from '../repositories/review.repository';
 import { tutorPayout } from '../payments/fees';
 
-// Allow-list of safe identity fields for list rows.
+// Allow-list of safe identity fields for list rows. studentRating /
+// studentRatingCount are private app-wide but deliberately visible here:
+// every consumer route is behind requireAdminUser and the directory's
+// best/worst-rating sort needs them on the row.
 const LIST_SELECT = {
   id: true,
   email: true,
@@ -29,6 +34,8 @@ const LIST_SELECT = {
   isActive: true,
   isEmailVerified: true,
   createdAt: true,
+  studentRating: true,
+  studentRatingCount: true,
   career: { select: { id: true, name: true, code: true } },
   tutorProfile: { select: { review: true, numReview: true, numSessions: true } },
 };
@@ -52,6 +59,10 @@ const PROFILE_SELECT = {
   suspendedReason: true,
   createdAt: true,
   updatedAt: true,
+  // Private student rating (tutor→estudiante): admins see it deliberately —
+  // it powers moderation / suspension for low ratings.
+  studentRating: true,
+  studentRatingCount: true,
   career: { select: { id: true, name: true, code: true, department: { select: { id: true, name: true } } } },
   tutorProfile: {
     select: {
@@ -102,15 +113,51 @@ function buildWhere({ role = 'all', search } = {}) {
 }
 
 /**
- * Paginated, searchable list of users. `search` matches name OR email
- * (case-insensitive); `role` is one of all|students|tutors|admins|suspended.
+ * Sort modes for the directory. The rating sorts rank by the denormalized
+ * aggregates and EXCLUDE users with zero ratings on that side — a 0-review
+ * default of 0.00 would otherwise pollute "worst rated" with brand-new users.
+ * `where` is merged on top of the role/search filter; `orderBy` always has a
+ * createdAt tie-breaker so pagination stays deterministic.
  */
-export async function listUsers({ role = 'all', search, limit = 50, offset = 0 } = {}) {
-  const where = buildWhere({ role, search: search?.trim() || undefined });
+const LIST_SORTS = {
+  recent: {
+    orderBy: [{ createdAt: 'desc' }],
+  },
+  tutorBest: {
+    where: { tutorProfile: { numReview: { gt: 0 } } },
+    orderBy: [{ tutorProfile: { review: 'desc' } }, { createdAt: 'desc' }],
+  },
+  tutorWorst: {
+    where: { tutorProfile: { numReview: { gt: 0 } } },
+    orderBy: [{ tutorProfile: { review: 'asc' } }, { createdAt: 'desc' }],
+  },
+  studentBest: {
+    where: { studentRatingCount: { gt: 0 } },
+    orderBy: [{ studentRating: 'desc' }, { createdAt: 'desc' }],
+  },
+  studentWorst: {
+    where: { studentRatingCount: { gt: 0 } },
+    orderBy: [{ studentRating: 'asc' }, { createdAt: 'desc' }],
+  },
+};
+
+export const LIST_SORT_KEYS = Object.keys(LIST_SORTS);
+
+/**
+ * Paginated, searchable list of users. `search` matches name OR email
+ * (case-insensitive); `role` is one of all|students|tutors|admins|suspended;
+ * `sort` is one of LIST_SORT_KEYS (default `recent`).
+ */
+export async function listUsers({ role = 'all', search, sort = 'recent', limit = 50, offset = 0 } = {}) {
+  const sortSpec = LIST_SORTS[sort] || LIST_SORTS.recent;
+  const where = {
+    ...buildWhere({ role, search: search?.trim() || undefined }),
+    ...(sortSpec.where || {}),
+  };
   const [items, total] = await Promise.all([
     prisma.user.findMany({
       where,
-      orderBy: { createdAt: 'desc' },
+      orderBy: sortSpec.orderBy,
       take: Math.max(1, Math.min(limit, 200)),
       skip: Math.max(0, offset),
       select: LIST_SELECT,
@@ -170,6 +217,7 @@ export async function getUserProfile(userId) {
     studentStats,
     financial,
     activityRaw,
+    studentReviewsReceived,
   ] = await Promise.all([
     prisma.tutorCourse.findMany({
       where: { tutorId: id },
@@ -199,13 +247,25 @@ export async function getUserProfile(userId) {
     statsRepo.studentSessionStats(id),
     statsRepo.financialStats(id),
     statsRepo.monthlyActivity(id, 12),
+    // Moderation view: comments included — admin-only by the route guard.
+    studentReviewRepo.findReceivedByStudent(id, 20),
   ]);
+
+  // Reviews received as TUTOR (the public student→tutor direction, with
+  // comments) so the admin sees behaviour on both sides of the marketplace.
+  // Outside Promise.all to keep the failure mode isolated: an empty list is
+  // fine for non-tutors.
+  const tutorReviewsReceived = user.isTutorApproved
+    ? await reviewRepo.findReviewsReceived(id, 20)
+    : [];
 
   return {
     user,
     tutorCourses,
     sessionsAsTutor,
     sessionsAsStudent,
+    studentReviewsReceived,
+    tutorReviewsReceived,
     activitySeries: buildActivitySeries(activityRaw, 12),
     stats: {
       asTutor: {
@@ -220,6 +280,8 @@ export async function getUserProfile(userId) {
         spent:           Number(financial.spentGross.toFixed(2)),
         payments:        financial.spentPayments,
         reviewsWritten:  user._count?.reviewsWritten ?? 0,
+        rating:          Number(user.studentRating) || 0,
+        ratingCount:     user.studentRatingCount ?? 0,
       },
     },
   };

--- a/src/lib/services/notification.service.js
+++ b/src/lib/services/notification.service.js
@@ -219,6 +219,28 @@ export async function notifyReviewReceived(tutorId, studentName, rating, session
   });
 }
 
+/**
+ * Tutor receives: reminder to rate their students after completing a session
+ * (reciprocal review, estilo Uber). The resulting rating is private — students
+ * are deliberately NOT notified when a tutor rates them.
+ */
+export async function notifyRateStudents(session) {
+  const courseName = session.course?.name || 'Tutoría';
+  const participants = session.participants || [];
+  const firstName = participants[0]?.student?.name;
+  const message =
+    participants.length === 1 && firstName
+      ? `¿Cómo te fue con ${firstName}? Califica a tu estudiante de ${courseName}.`
+      : `Califica a tus estudiantes de ${courseName}.`;
+  return notify({
+    userId: session.tutorId,
+    type: 'student_review_reminder',
+    message,
+    sessionId: session.id,
+    metadata: { courseName },
+  });
+}
+
 // ─── Session reminder (prepared for future cron) ──────────────────────
 
 /** Both tutor and students receive: reminder before session starts */

--- a/src/lib/services/session.service.js
+++ b/src/lib/services/session.service.js
@@ -11,6 +11,7 @@ import * as sessionRepo from '../repositories/session.repository';
 import * as availabilityRepo from '../repositories/availability.repository';
 import * as userRepo from '../repositories/user.repository';
 import * as reviewRepo from '../repositories/review.repository';
+import * as studentReviewRepo from '../repositories/student-review.repository';
 import * as tutorProfileRepo from '../repositories/tutor-profile.repository';
 import * as paymentRepo from '../repositories/payment.repository';
 import * as notificationService from './notification.service';
@@ -99,7 +100,56 @@ export async function getSessionById(id) {
 }
 
 export async function getSessionsByTutor(tutorId, limit = 50) {
-  return sessionRepo.findByTutor(tutorId, limit);
+  const sessions = await sessionRepo.findByTutor(tutorId, limit);
+  return enrichSessionsForTutor(sessions, tutorId);
+}
+
+/**
+ * Attach tutor-only data to session payloads (PRIVATE — never call for
+ * student-facing responses):
+ *  - each participant's aggregate rating as a student (estilo Uber:
+ *    studentRating / studentRatingCount on participant.student)
+ *  - `studentReviews`: the reviews THIS tutor wrote for the session
+ *    (pending placeholders + done), powering the "califica a tus
+ *    estudiantes" UI state and edit prefill.
+ * Two batch queries total, regardless of list size.
+ */
+export async function enrichSessionsForTutor(sessions, tutorId) {
+  if (!sessions || sessions.length === 0) return sessions;
+
+  const studentIds = [
+    ...new Set(
+      sessions.flatMap((s) => (s.participants || []).map((p) => p.studentId)),
+    ),
+  ];
+  const sessionIds = sessions.map((s) => s.id);
+
+  const [ratingsMap, reviewsBySession] = await Promise.all([
+    studentReviewRepo.getStudentRatingsMap(studentIds),
+    studentReviewRepo.findBySessionIdsForTutor(sessionIds, tutorId),
+  ]);
+
+  return sessions.map((session) => ({
+    ...session,
+    participants: (session.participants || []).map((p) => {
+      const rating = ratingsMap.get(p.studentId);
+      return {
+        ...p,
+        student: {
+          ...p.student,
+          studentRating: rating?.average ?? 0,
+          studentRatingCount: rating?.count ?? 0,
+        },
+      };
+    }),
+    studentReviews: reviewsBySession.get(session.id) || [],
+  }));
+}
+
+/** Single-session variant — used by GET /api/sessions/:id when the caller is the tutor. */
+export async function enrichSessionForTutor(session, tutorId) {
+  const [enriched] = await enrichSessionsForTutor([session], tutorId);
+  return enriched;
 }
 
 export async function getSessionsByStudent(studentId, limit = 50) {
@@ -190,7 +240,8 @@ export async function getStudentHistory(studentId, limit = 50) {
 }
 
 export async function getSessionsByTutorAndStatus(tutorId, status, limit = 50) {
-  return sessionRepo.findByTutorAndStatus(tutorId, status, limit);
+  const sessions = await sessionRepo.findByTutorAndStatus(tutorId, status, limit);
+  return enrichSessionsForTutor(sessions, tutorId);
 }
 
 export async function getStudentStats(userId) {
@@ -604,6 +655,9 @@ export async function completeSession(sessionId, tutorId) {
   const tutor = await userRepo.findById(tutorId);
   notificationService.notifySessionCompleted(session, tutor?.name || 'Tu tutor');
 
+  // Remind the tutor to rate their students (reciprocal review, estilo Uber)
+  notificationService.notifyRateStudents(session);
+
   // Auto-create pending review placeholders (student → tutor, one per participant)
   const participants = session.participants || [];
   await Promise.all(
@@ -618,6 +672,14 @@ export async function completeSession(sessionId, tutorId) {
         status: 'pending',
         comment: null,
       })
+    )
+  );
+
+  // Auto-create pending placeholders for the reciprocal direction
+  // (tutor → student, one per participant)
+  await Promise.all(
+    participants.map((p) =>
+      studentReviewRepo.createPendingStudentReview(sessionId, tutorId, p.studentId)
     )
   );
 

--- a/src/lib/services/student-review.service.js
+++ b/src/lib/services/student-review.service.js
@@ -1,0 +1,111 @@
+/**
+ * Student Review Service
+ * Business logic for tutor→student reviews (reciprocal rating, estilo Uber).
+ *
+ * Rules (mirror of review.service for the opposite direction):
+ * - Only sessions that already ended and were not Canceled/Rejected can be reviewed.
+ * - Reviewer must be the session's assigned tutor.
+ * - Reviewee must be a participant of that session.
+ * - One review per (session, tutor, student) — upsert on duplicate (editable).
+ *
+ * Visibility: the individual review (incl. comment) is only for the tutor who
+ * wrote it and for admins. Students only ever see their aggregate number.
+ */
+
+import * as studentReviewRepo from '../repositories/student-review.repository';
+import * as sessionRepo from '../repositories/session.repository';
+
+/**
+ * Create or edit a tutor→student review for a finished session.
+ */
+export async function createStudentReview(sessionId, tutorId, { studentId, rating, comment }) {
+  // 0. Validate rating is in valid range (1-5)
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    const err = new Error('La calificación debe ser un número entero entre 1 y 5');
+    err.code = 'INVALID_RATING';
+    throw err;
+  }
+
+  // 1. Load the session
+  const session = await sessionRepo.findById(sessionId);
+  if (!session) {
+    const err = new Error('Session not found');
+    err.code = 'NOT_FOUND';
+    throw err;
+  }
+
+  // 2. Validate session is eligible for rating
+  const now = new Date();
+  if (new Date(session.endTimestamp) > now) {
+    const err = new Error('La sesión aún no ha terminado');
+    err.code = 'SESSION_NOT_ENDED';
+    throw err;
+  }
+  if (session.status === 'Canceled' || session.status === 'Rejected') {
+    const err = new Error('No se puede calificar una sesión cancelada o rechazada');
+    err.code = 'SESSION_NOT_ELIGIBLE';
+    throw err;
+  }
+
+  // 3. Reviewer must be the session's tutor
+  if (session.tutorId !== tutorId) {
+    const err = new Error('Solo el tutor asignado puede calificar a los estudiantes de esta sesión');
+    err.code = 'NOT_SESSION_TUTOR';
+    throw err;
+  }
+
+  // 4. Reviewee must be a participant of this session
+  const isParticipant = session.participants?.some((p) => p.studentId === studentId);
+  if (!isParticipant) {
+    const err = new Error('El estudiante no participó en esta sesión');
+    err.code = 'INVALID_STUDENT';
+    throw err;
+  }
+
+  // 5. Track whether this is an edit (used by the API for the status code).
+  const existing = await studentReviewRepo.findBySessionForTutor(sessionId, tutorId);
+  const wasAlreadyDone = existing.some((r) => r.studentId === studentId && r.status === 'done');
+
+  // 6. Upsert with rating and mark as done, then recompute the student's
+  // denormalized aggregate (transactional, recomputed from scratch so edits
+  // stay consistent).
+  const review = await studentReviewRepo.upsertStudentReview({
+    sessionId,
+    tutorId,
+    studentId,
+    rating,
+    status: 'done',
+    comment: comment || null,
+  });
+
+  await studentReviewRepo.updateStudentRatingStats(studentId);
+
+  // Deliberately NO notification to the student: the per-session rating is
+  // private (Uber-style). The student only ever sees their aggregate.
+
+  return { review, updated: wasAlreadyDone };
+}
+
+/**
+ * Reviews the tutor wrote for one session (pending placeholders + done) —
+ * powers the "rate your students" UI state and edit prefill.
+ */
+export async function getSessionStudentReviewsForTutor(sessionId, tutorId) {
+  return studentReviewRepo.findBySessionForTutor(sessionId, tutorId);
+}
+
+/**
+ * The caller's own aggregate as a student: { average, count }. Number only —
+ * comments are never exposed here.
+ */
+export async function getOwnStudentRating(userId) {
+  return studentReviewRepo.getStudentRating(userId);
+}
+
+/**
+ * Admin moderation view: reviews received by a student, including comments
+ * and tutor identity. Must only be called behind requireAdminUser.
+ */
+export async function getStudentReviewsReceived(studentId, limit = 50) {
+  return studentReviewRepo.findReceivedByStudent(studentId, limit);
+}

--- a/src/lib/services/user.service.js
+++ b/src/lib/services/user.service.js
@@ -7,6 +7,19 @@ import crypto from 'crypto';
 import * as userRepository from '../repositories/user.repository';
 import * as reviewRepository from '../repositories/review.repository';
 
+/**
+ * Hash a magic-link token before persisting it. We store only the hash in the
+ * DB so a database leak does not hand out usable reset/verification tokens.
+ * The tokens are 32 bytes of CSPRNG output, so a plain SHA-256 (no salt) is
+ * safe AND deterministic — letting us look the user up by exact hash match.
+ *
+ * @param {string} token - The raw token (the value emailed to the user)
+ * @returns {string} Hex-encoded SHA-256 of the token
+ */
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
 // ---------------------------------------------------------------------------
 // User CRUD
 // ---------------------------------------------------------------------------
@@ -74,8 +87,9 @@ export async function createVerificationToken(userId) {
   const verificationTokenExpiry = new Date(
     Date.now() + VERIFICATION_TOKEN_EXPIRY_HOURS * 60 * 60 * 1000,
   );
+  // Persist only the hash; the raw token travels in the email and is never stored.
   await userRepository.update(userId, {
-    verificationToken: token,
+    verificationToken: hashToken(token),
     verificationTokenExpiry,
     isEmailVerified: false,
   });
@@ -89,7 +103,7 @@ export async function createVerificationToken(userId) {
  * @returns {Promise<{status: string, user: Object|null}>}
  */
 export async function verifyEmailToken(token) {
-  const user = await userRepository.findByVerificationToken(token);
+  const user = await userRepository.findByVerificationToken(hashToken(token));
   if (!user) return { status: 'invalid', user: null };
   if (user.isEmailVerified) return { status: 'already', user };
 
@@ -138,7 +152,8 @@ export async function createResetToken(userId) {
   const resetToken = crypto.randomBytes(32).toString('hex');
   const resetTokenExpiry = new Date(Date.now() + RESET_TOKEN_EXPIRY_MINUTES * 60 * 1000);
 
-  await userRepository.update(userId, { resetToken, resetTokenExpiry });
+  // Persist only the hash; the raw token travels in the reset link, never stored.
+  await userRepository.update(userId, { resetToken: hashToken(resetToken), resetTokenExpiry });
 
   return resetToken;
 }
@@ -149,7 +164,7 @@ export async function createResetToken(userId) {
  * @returns {Promise<Object|null>} The user if valid, null otherwise
  */
 export async function validateResetToken(token) {
-  const user = await userRepository.findByResetToken(token);
+  const user = await userRepository.findByResetToken(hashToken(token));
   if (!user) return null;
 
   if (Date.now() > new Date(user.resetTokenExpiry).getTime()) {
@@ -173,32 +188,71 @@ export async function clearResetFields(userId) {
   });
 }
 
+// Max failed OTP guesses allowed against a single issued code before it's
+// invalidated. Combined with the per-email/IP rate limit on the route, this
+// makes brute-forcing a 6-digit OTP infeasible even across multiple instances
+// (the counter lives in the DB, not in per-process memory).
+const MAX_OTP_ATTEMPTS = 5;
+
 /**
- * Verify OTP code and create a reset token for password reset flow.
- * @param {string} email - User email
+ * Constant-time string comparison. Avoids leaking how many leading characters
+ * matched via response timing. Returns false fast on length mismatch (which is
+ * not secret here — OTPs are a fixed 6 digits).
+ */
+function safeEqual(a, b) {
+  const ab = Buffer.from(String(a ?? ''));
+  const bb = Buffer.from(String(b ?? ''));
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+/**
+ * Verify an OTP code and, on success, create a reset token for the password
+ * reset flow. Enforces a DB-backed attempt counter: after MAX_OTP_ATTEMPTS
+ * failures the code is invalidated so it cannot be brute-forced.
+ *
+ * NOTE: whatever issues a new OTP (`otpCode`/`otpCodeExpiry`) MUST also reset
+ * `otpAttempts` to 0, or the user could start locked out.
+ *
+ * @param {string} email - User email (expected already normalized/lowercased)
  * @param {string} otpCode - 6-digit OTP code
- * @returns {object} { valid: boolean, resetToken?: string }
+ * @returns {Promise<{ valid: boolean, resetToken?: string, locked?: boolean }>}
  */
 export async function verifyOtp(email, otpCode) {
-  const user = await userRepository.findByEmail(email);
-  
-  if (!user) {
+  const user = await userRepository.findOtpStateByEmail(email);
+
+  // No user, or no OTP currently issued → nothing to verify.
+  if (!user || !user.otpCode) {
     return { valid: false };
   }
 
-  // Check if OTP matches and is not expired
-  const now = new Date();
-  if (user.otpCode !== otpCode || (user.otpCodeExpiry && user.otpCodeExpiry < now)) {
+  // Lockout: the current code already burned through its allowed attempts.
+  if ((user.otpAttempts ?? 0) >= MAX_OTP_ATTEMPTS) {
+    await userRepository.update(user.id, { otpCode: null, otpCodeExpiry: null, otpAttempts: 0 });
+    return { valid: false, locked: true };
+  }
+
+  const expired = user.otpCodeExpiry && new Date(user.otpCodeExpiry) < new Date();
+  const matches = safeEqual(user.otpCode, otpCode);
+
+  if (expired || !matches) {
+    const attempts = (user.otpAttempts ?? 0) + 1;
+    // Invalidate the code on expiry or once the attempt cap is reached;
+    // otherwise just record the failed attempt.
+    if (expired || attempts >= MAX_OTP_ATTEMPTS) {
+      await userRepository.update(user.id, { otpCode: null, otpCodeExpiry: null, otpAttempts: 0 });
+    } else {
+      await userRepository.update(user.id, { otpAttempts: attempts });
+    }
     return { valid: false };
   }
 
-  // Create reset token for password reset
+  // Success: issue the reset token and clear all OTP state.
   const resetToken = await createResetToken(user.id);
-  
-  // Clear OTP fields
   await userRepository.update(user.id, {
     otpCode: null,
     otpCodeExpiry: null,
+    otpAttempts: 0,
   });
 
   return { valid: true, resetToken };


### PR DESCRIPTION
## Resumen

Dos bloques de trabajo en este PR:

1. **Feature — Calificación recíproca tutor → estudiante** (estilo Uber): el tutor
   califica al estudiante al completar la sesión. El agregado es **privado**; incluye
   panel de administración para moderación.
2. **Endurecimiento de seguridad**: cierra fugas de datos (IDOR + privacidad), frena
   fuerza bruta de OTP y añade hardening base.

Base: `dev`. **Requiere migración de BD** (ver abajo).

---

## 1. Feature: calificación recíproca tutor → estudiante

**Modelo de datos**
- Tabla nueva `StudentReview` + campos `User.studentRating` / `studentRatingCount`
  (agregado denormalizado, mismo patrón que `TutorProfile.review`). Tabla separada de
  `Review` a propósito: la visibilidad opuesta (privada vs pública) queda estructural.

**Backend**
- `student-review.repository.js`, `student-review.service.js`,
  `POST/GET /api/sessions/[id]/student-reviews`, `GET /api/users/me/student-rating`.

**Flujo de tutor (UI)**
- Nuevo `StudentReviewModal` (+ pantalla de éxito), integrado en `SessionDetailView` y
  disparado desde notificaciones (`NotificationDropdown`).

**Panel de administración (moderación)**
- **Detalle de usuario** (`admin/users/[userId]`): cabecera con los dos promedios lado a
  lado — ★ ámbar "Como tutor" y ★ azul "Como estudiante" — y dos secciones de comentarios
  en grid: *"Reseñas recibidas de estudiantes"* (públicas) y *"Calificaciones recibidas de
  tutores"* (privadas, con nota de que solo las ve el equipo de Calico). Mismo formato:
  autor, estrellas, materia, fecha y comentario.
- **Directorio** (`admin/users`): selector **"Ordenar por"** (Más recientes / Mejor·Peor
  calificados como tutor / Mejor·Peor como estudiante), combinable con pestañas de rol y
  búsqueda. Los sorts por calificación **excluyen a usuarios sin calificaciones** (si no,
  "peor calificados" se llenaría de usuarios nuevos en 0.00) y el contador lo indica.
  Cada fila muestra ambos ratings etiquetados (`★ 4.85 (12) · como tutor`).

**Privacidad (auditoría completa)**
- Se recorrieron todos los caminos que devuelven usuarios/sesiones. `login` y
  `request-tutor` hacían su propio strip manual con una lista vieja y **filtraban la
  puntuación privada**. Ahora `user.repository` exporta **`sanitizeUser` (única lista de
  strip en todo el codebase)** y ambas rutas la usan. Google auth re-fetchea sanitizado;
  `/api/tutors/[id]` y las queries de sesión usan `select` explícito. Test unitario nuevo
  de `sanitizeUser` protege la lista contra regresiones.

**i18n / diseño / arquitectura**
- Textos nuevos 100% vía `t()` con paridad ES/EN.
- Estética del panel admin existente (cards `rounded-2xl`, badges, ámbar/sky por rol).
  Responsive solo con los breakpoints oficiales del proyecto (`sm:` apila buscador+orden,
  `lg:` lleva reseñas a 2 columnas, cabecera de ratings fila→columna en `sm:`).
- Arquitectura de 4 capas respetada: `admin-users.service` (allow-list `LIST_SORT_KEYS` +
  `tutorReviewsReceived`) → route con validación del param → `AdminService` → página.

## 2. Seguridad

**Críticos (fuga activa de datos — IDOR):**
- `GET /api/payments/student/[email]` y `GET /api/payments/tutor/[tutorId]` estaban
  **sin autenticación** (exponían historial de pagos, montos y emails de estudiantes a
  cualquiera). Ahora exigen JWT y solo permiten al **dueño o a un admin** (identidad del
  token, nunca de la URL). Helper nuevo `isAdmin(userId)` en `guards.js`.

**Alto — fuerza bruta de OTP / toma de cuenta:**
- `POST /api/auth/verify-otp`: **rate limit** (por IP y email) + **contador de intentos
  en BD** (`User.otpAttempts`, se invalida el código a los 5 fallos) + comparación en
  **tiempo constante**. De paso se corrigió que `verifyOtp` nunca funcionaba (leía
  `otpCode` ya sanitizado); se añadió `findOtpStateByEmail`. ⚠️ Quien implemente el envío
  de OTP debe poner `otpAttempts = 0` al emitir un código nuevo (documentado).

**Hardening:**
- **Cabeceras de seguridad** en `next.config.mjs`: HSTS, `X-Content-Type-Options`,
  `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy`, `Permissions-Policy`. *(CSP estricta
  excluida a propósito: rompe inline scripts de Next + Wompi + Google OAuth; requiere
  pasada dedicada.)*
- **Tokens de reset/verificación hasheados (SHA-256)** antes de persistir: una filtración
  de BD ya no entrega tokens usables.

---

## Migración de BD ⚠️

Cambios de esquema **aditivos** (no destructivos). En cada entorno:

```bash
npx prisma db push   # o el flujo de migración del equipo
npx prisma generate
