### PR TITLE
Comentarios tutor→estudiante: write-only/write-once + aceptación a ciegas + filtro por materia (admin)

### DIFF
--- a/src/__tests__/api/admin-student-reviews.api.test.js
+++ b/src/__tests__/api/admin-student-reviews.api.test.js
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment node
+ *
+ * GET /api/admin/users/:userId/student-reviews — admin moderation of the
+ * tutor→student reviews received by a user, with a materia filter resolved
+ * through the session→course relation (NO denormalized course column).
+ *
+ * Verifies:
+ *  - requireAdminUser gates the route (only admins read the comment text).
+ *  - The response carries reviews (incl. comments) + distinct courses.
+ *  - The materia filter is applied as a relation filter (`session.courseId`),
+ *    proving the model stays normalized.
+ */
+
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    studentReview: { findMany: jest.fn() },
+  },
+}));
+
+jest.mock('@/lib/auth/guards', () => ({
+  requireAdminUser: jest.fn(),
+}));
+
+const { NextResponse } = require('next/server');
+const prisma = require('@/lib/prisma').default;
+const { requireAdminUser } = require('@/lib/auth/guards');
+
+const ADMIN = { sub: 'admin-1', email: 'admin@test.co', role: 'ADMIN' };
+
+let GET;
+beforeAll(() => {
+  GET = require('@/app/api/admin/users/[userId]/student-reviews/route').GET;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  prisma.studentReview.findMany.mockResolvedValue([]);
+});
+
+it('rejects non-admins via requireAdminUser', async () => {
+  requireAdminUser.mockResolvedValue(
+    NextResponse.json({ success: false, error: 'FORBIDDEN' }, { status: 403 }),
+  );
+
+  const res = await GET(new Request('http://x/api/admin/users/u1/student-reviews'), {
+    params: Promise.resolve({ userId: 'u1' }),
+  });
+
+  expect(res.status).toBe(403);
+  expect(prisma.studentReview.findMany).not.toHaveBeenCalled();
+});
+
+it('returns reviews (with comments) + distinct courses for an admin', async () => {
+  requireAdminUser.mockResolvedValue(ADMIN);
+  prisma.studentReview.findMany
+    .mockResolvedValueOnce([
+      {
+        id: 'sr1',
+        rating: 5,
+        comment: 'Muy puntual',
+        tutor: { id: 't1', name: 'Tutor' },
+        session: { id: 's1', startTimestamp: new Date(), course: { id: 'c1', name: 'Cálculo I', code: 'MAT101' } },
+      },
+    ])
+    .mockResolvedValueOnce([
+      { session: { course: { id: 'c1', name: 'Cálculo I', code: 'MAT101' } } },
+      { session: { course: { id: 'c1', name: 'Cálculo I', code: 'MAT101' } } }, // duplicate → deduped
+    ]);
+
+  const res = await GET(new Request('http://x/api/admin/users/u1/student-reviews'), {
+    params: Promise.resolve({ userId: 'u1' }),
+  });
+  const body = await res.json();
+
+  expect(res.status).toBe(200);
+  expect(body.success).toBe(true);
+  expect(body.reviews).toHaveLength(1);
+  // Admin IS allowed to read the comment text (only surface that exposes it).
+  expect(body.reviews[0].comment).toBe('Muy puntual');
+  // Distinct materias, deduped, reached via the session relation.
+  expect(body.courses).toEqual([{ id: 'c1', name: 'Cálculo I', code: 'MAT101' }]);
+});
+
+it('filters by materia through the session relation (normalized, no course column)', async () => {
+  requireAdminUser.mockResolvedValue(ADMIN);
+
+  const res = await GET(new Request('http://x/api/admin/users/u1/student-reviews?courseId=c1'), {
+    params: Promise.resolve({ userId: 'u1' }),
+  });
+
+  expect(res.status).toBe(200);
+  // Identify the reviews query (it uses `include`; the courses query uses `select`).
+  const reviewsCall = prisma.studentReview.findMany.mock.calls.find(([arg]) => arg.include);
+  expect(reviewsCall[0].where).toMatchObject({
+    studentId: 'u1',
+    status: 'done',
+    session: { courseId: 'c1' },
+  });
+  // There must be NO denormalized courseId column on student_reviews.
+  expect(reviewsCall[0].where).not.toHaveProperty('courseId');
+});

--- a/src/__tests__/api/student-reviews.api.test.js
+++ b/src/__tests__/api/student-reviews.api.test.js
@@ -5,12 +5,15 @@
  * Exercises route handler → service → repository with Prisma mocked at the
  * singleton level (same pattern as user-reviews.api.test.js).
  *
- * Routes covered:
- *   POST /api/sessions/:id/student-reviews — create/edit (tutor only)
- *   GET  /api/sessions/:id/student-reviews — caller's own reviews only
+ * Contract under test:
+ *   POST /api/sessions/:id/student-reviews — publish WRITE-ONCE (tutor only);
+ *                                            response carries only { status },
+ *                                            409 ALREADY_REVIEWED on re-publish.
+ *   GET  /api/sessions/:id/student-reviews — content-free { studentId, status }
+ *                                            only (no rating, no comment).
  *   GET  /api/users/me/student-rating      — own aggregate (number only)
- *   GET  /api/sessions & /api/sessions/:id — PRIVACY: rating attached only
- *                                            to tutor payloads
+ *   GET  /api/sessions & /api/sessions/:id — PRIVACY: tutors get the star
+ *                                            AVERAGE only (no count, no comments).
  */
 
 jest.mock('@/lib/prisma', () => ({
@@ -18,7 +21,13 @@ jest.mock('@/lib/prisma', () => ({
   default: {
     user: { findMany: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
     session: { findMany: jest.fn(), findUnique: jest.fn() },
-    studentReview: { findMany: jest.fn(), upsert: jest.fn() },
+    studentReview: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      upsert: jest.fn(),
+    },
     $transaction: jest.fn(),
   },
 }));
@@ -73,6 +82,9 @@ beforeEach(() => {
   // $transaction: run the callback against the same prisma mock as tx
   prisma.$transaction.mockImplementation(async (cb) => cb(prisma));
   prisma.studentReview.findMany.mockResolvedValue([]);
+  prisma.studentReview.findUnique.mockResolvedValue(null); // no existing review → create path
+  prisma.studentReview.create.mockResolvedValue({ id: 'sr-1' });
+  prisma.studentReview.update.mockResolvedValue({ id: 'sr-1' });
   prisma.user.update.mockResolvedValue({ id: 'student-1', studentRating: 4, studentRatingCount: 1 });
 });
 
@@ -95,7 +107,7 @@ describe('POST /api/sessions/:id/student-reviews', () => {
     );
 
     expect(res.status).toBe(403);
-    expect(prisma.studentReview.upsert).not.toHaveBeenCalled();
+    expect(prisma.studentReview.create).not.toHaveBeenCalled();
   });
 
   it('returns 400 on out-of-range rating (zod)', async () => {
@@ -110,45 +122,42 @@ describe('POST /api/sessions/:id/student-reviews', () => {
     expect(prisma.session.findUnique).not.toHaveBeenCalled();
   });
 
-  it('creates the review (201), upserting as done and recomputing the aggregate', async () => {
+  it('publishes write-once (201) returning only a status — never the comment', async () => {
     requireTutor.mockReturnValue(TUTOR_AUTH);
     prisma.session.findUnique.mockResolvedValue(makeDbSession());
-    prisma.studentReview.upsert.mockResolvedValue({
-      id: 'sr-1', sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1',
-      rating: 5, status: 'done', comment: null,
-    });
 
     const res = await POST(
-      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 5 }),
+      buildPost('http://x/api/sessions/session-1/student-reviews', {
+        studentId: 'student-1',
+        rating: 5,
+        comment: 'Muy participativo',
+      }),
       { params: Promise.resolve({ id: 'session-1' }) },
     );
     const body = await res.json();
 
     expect(res.status).toBe(201);
-    expect(body.success).toBe(true);
-    expect(body.review.status).toBe('done');
+    expect(body).toEqual({ success: true, status: 'done' });
+    // The stored comment/rating must NOT be echoed back to the tutor.
+    expect(body).not.toHaveProperty('review');
+    expect(JSON.stringify(body)).not.toContain('Muy participativo');
 
-    const upsertArgs = prisma.studentReview.upsert.mock.calls[0][0];
-    expect(upsertArgs.where).toEqual({
-      sessionId_tutorId_studentId: { sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1' },
-    });
-    expect(upsertArgs.create).toMatchObject({ rating: 5, status: 'done' });
+    // No prior row → create path, persisted as done.
+    expect(prisma.studentReview.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ rating: 5, status: 'done', comment: 'Muy participativo' }),
+      }),
+    );
     // Aggregate recomputed on the user row
     expect(prisma.user.update).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: 'student-1' } }),
     );
   });
 
-  it('returns 200 + updated=true when editing an existing done review', async () => {
+  it('returns 409 ALREADY_REVIEWED when a published review already exists (no edits)', async () => {
     requireTutor.mockReturnValue(TUTOR_AUTH);
     prisma.session.findUnique.mockResolvedValue(makeDbSession());
-    prisma.studentReview.findMany.mockResolvedValue([
-      { id: 'sr-1', sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1', status: 'done', rating: 3 },
-    ]);
-    prisma.studentReview.upsert.mockResolvedValue({
-      id: 'sr-1', sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1',
-      rating: 5, status: 'done', comment: null,
-    });
+    prisma.studentReview.findUnique.mockResolvedValue({ id: 'sr-1', status: 'done' });
 
     const res = await POST(
       buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 5 }),
@@ -156,8 +165,29 @@ describe('POST /api/sessions/:id/student-reviews', () => {
     );
     const body = await res.json();
 
-    expect(res.status).toBe(200);
-    expect(body.updated).toBe(true);
+    expect(res.status).toBe(409);
+    expect(body.code).toBe('ALREADY_REVIEWED');
+    expect(prisma.studentReview.create).not.toHaveBeenCalled();
+    expect(prisma.studentReview.update).not.toHaveBeenCalled();
+    // Nothing published ⇒ aggregate must not be recomputed.
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('transitions a pending placeholder to done (one-way)', async () => {
+    requireTutor.mockReturnValue(TUTOR_AUTH);
+    prisma.session.findUnique.mockResolvedValue(makeDbSession());
+    prisma.studentReview.findUnique.mockResolvedValue({ id: 'sr-1', status: 'pending' });
+
+    const res = await POST(
+      buildPost('http://x/api/sessions/session-1/student-reviews', { studentId: 'student-1', rating: 4 }),
+      { params: Promise.resolve({ id: 'session-1' }) },
+    );
+
+    expect(res.status).toBe(201);
+    expect(prisma.studentReview.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'done', rating: 4 }) }),
+    );
+    expect(prisma.studentReview.create).not.toHaveBeenCalled();
   });
 
   it('returns 403 NOT_SESSION_TUTOR when the caller is a tutor of another session', async () => {
@@ -172,7 +202,7 @@ describe('POST /api/sessions/:id/student-reviews', () => {
 
     expect(res.status).toBe(403);
     expect(body.code).toBe('NOT_SESSION_TUTOR');
-    expect(prisma.studentReview.upsert).not.toHaveBeenCalled();
+    expect(prisma.studentReview.create).not.toHaveBeenCalled();
   });
 
   it('returns 400 INVALID_STUDENT when the reviewee is not a participant', async () => {
@@ -228,10 +258,10 @@ describe('GET /api/sessions/:id/student-reviews', () => {
     GET = require('@/app/api/sessions/[id]/student-reviews/route').GET;
   });
 
-  it('only ever returns reviews written by the calling tutor', async () => {
+  it('returns only the content-free { studentId, status } targets for the caller', async () => {
     requireTutor.mockReturnValue(TUTOR_AUTH);
     prisma.studentReview.findMany.mockResolvedValue([
-      { id: 'sr-1', tutorId: 'tutor-1', studentId: 'student-1', status: 'pending', rating: null },
+      { studentId: 'student-1', status: 'pending' },
     ]);
 
     const res = await GET(new Request('http://x/api/sessions/session-1/student-reviews'), {
@@ -241,10 +271,15 @@ describe('GET /api/sessions/:id/student-reviews', () => {
 
     expect(body.success).toBe(true);
     expect(body.count).toBe(1);
-    // The where clause is pinned to the caller's id — not just the session
-    expect(prisma.studentReview.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { sessionId: 'session-1', tutorId: 'tutor-1' } }),
-    );
+    expect(body.targets).toEqual([{ studentId: 'student-1', status: 'pending' }]);
+    // No comment/rating must ever cross this boundary.
+    expect(JSON.stringify(body)).not.toContain('comment');
+    expect(body.reviews).toBeUndefined();
+
+    // Pinned to the caller's id, and the projection is status-only.
+    const call = prisma.studentReview.findMany.mock.calls[0][0];
+    expect(call.where).toEqual({ sessionId: 'session-1', tutorId: 'tutor-1' });
+    expect(call.select).toEqual({ studentId: true, status: true });
   });
 
   it('rejects students (guard)', async () => {
@@ -297,7 +332,7 @@ describe('GET /api/users/me/student-rating', () => {
 
 // ─── PRIVACY: session payload gating ────────────────────────────────
 
-describe('PRIVACY — student rating only reaches tutor payloads', () => {
+describe('PRIVACY — tutors get the star average only', () => {
   let GET_SESSIONS;
   let GET_SESSION;
   beforeAll(() => {
@@ -305,14 +340,14 @@ describe('PRIVACY — student rating only reaches tutor payloads', () => {
     GET_SESSION = require('@/app/api/sessions/[id]/route').GET;
   });
 
-  it('GET /api/sessions?role=tutor attaches studentRating + studentReviews', async () => {
+  it('GET /api/sessions?role=tutor attaches studentRating (avg) + content-free status, NO count/comments', async () => {
     authenticateRequest.mockReturnValue(TUTOR_AUTH);
     prisma.session.findMany.mockResolvedValue([makeDbSession()]);
     prisma.user.findMany.mockResolvedValue([
       { id: 'student-1', studentRating: '4.75', studentRatingCount: 12 },
     ]);
     prisma.studentReview.findMany.mockResolvedValue([
-      { id: 'sr-1', sessionId: 'session-1', tutorId: 'tutor-1', studentId: 'student-1', status: 'pending', rating: null },
+      { sessionId: 'session-1', studentId: 'student-1', status: 'pending' },
     ]);
 
     const res = await GET_SESSIONS(new Request('http://x/api/sessions?role=tutor'));
@@ -321,8 +356,28 @@ describe('PRIVACY — student rating only reaches tutor payloads', () => {
     expect(body.success).toBe(true);
     const participant = body.sessions[0].participants[0];
     expect(participant.student.studentRating).toBe(4.75);
-    expect(participant.student.studentRatingCount).toBe(12);
-    expect(body.sessions[0].studentReviews).toHaveLength(1);
+    // Count and comment content must never travel to a tutor.
+    expect(participant.student.studentRatingCount).toBeUndefined();
+    expect(body.sessions[0].studentReviews).toBeUndefined();
+    expect(body.sessions[0].studentReviewStatus).toEqual([
+      { studentId: 'student-1', status: 'pending' },
+    ]);
+  });
+
+  it('exposes studentRating = null (never 0/count) for a student with no ratings yet', async () => {
+    authenticateRequest.mockReturnValue(TUTOR_AUTH);
+    prisma.session.findMany.mockResolvedValue([makeDbSession()]);
+    prisma.user.findMany.mockResolvedValue([
+      { id: 'student-1', studentRating: '0', studentRatingCount: 0 },
+    ]);
+    prisma.studentReview.findMany.mockResolvedValue([]);
+
+    const res = await GET_SESSIONS(new Request('http://x/api/sessions?role=tutor'));
+    const body = await res.json();
+
+    const participant = body.sessions[0].participants[0];
+    expect(participant.student.studentRating).toBeNull();
+    expect(participant.student.studentRatingCount).toBeUndefined();
   });
 
   it('GET /api/sessions (student) never queries nor attaches ratings', async () => {
@@ -335,17 +390,21 @@ describe('PRIVACY — student rating only reaches tutor payloads', () => {
     expect(body.success).toBe(true);
     const participant = body.sessions[0].participants[0];
     expect(participant.student.studentRating).toBeUndefined();
+    expect(body.sessions[0].studentReviewStatus).toBeUndefined();
     expect(body.sessions[0].studentReviews).toBeUndefined();
     // The ratings batch query must not run for student payloads
     expect(prisma.user.findMany).not.toHaveBeenCalled();
     expect(prisma.studentReview.findMany).not.toHaveBeenCalled();
   });
 
-  it('GET /api/sessions/:id enriches only when the caller is the session tutor', async () => {
+  it('GET /api/sessions/:id enriches the tutor with avg + status only (no count, no comments)', async () => {
     authenticateRequest.mockReturnValue(TUTOR_AUTH);
     prisma.session.findUnique.mockResolvedValue(makeDbSession());
     prisma.user.findMany.mockResolvedValue([
       { id: 'student-1', studentRating: '4.75', studentRatingCount: 12 },
+    ]);
+    prisma.studentReview.findMany.mockResolvedValue([
+      { studentId: 'student-1', status: 'done' },
     ]);
 
     const res = await GET_SESSION(new Request('http://x/api/sessions/session-1'), {
@@ -354,7 +413,13 @@ describe('PRIVACY — student rating only reaches tutor payloads', () => {
     const body = await res.json();
 
     expect(body.session.participants[0].student.studentRating).toBe(4.75);
-    expect(body.session.studentReviews).toBeDefined();
+    expect(body.session.participants[0].student.studentRatingCount).toBeUndefined();
+    expect(body.session.studentReviewStatus).toEqual([{ studentId: 'student-1', status: 'done' }]);
+    expect(body.session.studentReviews).toBeUndefined();
+
+    // The tutor-facing studentReview query must not select comment.
+    const srCall = prisma.studentReview.findMany.mock.calls[0][0];
+    expect(srCall.select).toEqual({ studentId: true, status: true });
   });
 
   it('GET /api/sessions/:id gives students a payload without ratings', async () => {
@@ -367,6 +432,7 @@ describe('PRIVACY — student rating only reaches tutor payloads', () => {
     const body = await res.json();
 
     expect(body.session.participants[0].student.studentRating).toBeUndefined();
+    expect(body.session.studentReviewStatus).toBeUndefined();
     expect(body.session.studentReviews).toBeUndefined();
     expect(prisma.user.findMany).not.toHaveBeenCalled();
   });

--- a/src/__tests__/services/student-review.service.test.js
+++ b/src/__tests__/services/student-review.service.test.js
@@ -1,13 +1,19 @@
 /**
  * Unit tests for student-review.service (tutor→student reciprocal reviews).
  * Mocks the repositories to verify business rules in isolation.
+ *
+ * New contract under test:
+ *  - WRITE-ONCE publish (no editing); ALREADY_REVIEWED bubbles up.
+ *  - The service returns ONLY a status flag — never the stored comment/rating.
+ *  - Tutor reads are content-free ({ studentId, status } only).
  */
 
 jest.mock('@/lib/repositories/student-review.repository', () => ({
-  upsertStudentReview: jest.fn(),
+  publishStudentReview: jest.fn(),
   updateStudentRatingStats: jest.fn(),
-  findBySessionForTutor: jest.fn(),
+  findStatusBySessionForTutor: jest.fn(),
   findReceivedByStudent: jest.fn(),
+  findReviewedCoursesByStudent: jest.fn(),
   getStudentRating: jest.fn(),
 }));
 
@@ -37,8 +43,7 @@ function makeSession(overrides = {}) {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  studentReviewRepo.findBySessionForTutor.mockResolvedValue([]);
-  studentReviewRepo.upsertStudentReview.mockImplementation(async (data) => ({ id: 'sr-1', ...data }));
+  studentReviewRepo.publishStudentReview.mockResolvedValue({ status: 'done' });
   studentReviewRepo.updateStudentRatingStats.mockResolvedValue({});
 });
 
@@ -87,7 +92,7 @@ describe('createStudentReview — validations', () => {
     await expect(
       service.createStudentReview(SESSION_ID, 'another-tutor', { studentId: STUDENT_ID, rating: 4 }),
     ).rejects.toMatchObject({ code: 'NOT_SESSION_TUTOR' });
-    expect(studentReviewRepo.upsertStudentReview).not.toHaveBeenCalled();
+    expect(studentReviewRepo.publishStudentReview).not.toHaveBeenCalled();
   });
 
   it('rejects when the reviewee did not participate (INVALID_STUDENT)', async () => {
@@ -96,12 +101,12 @@ describe('createStudentReview — validations', () => {
     await expect(
       service.createStudentReview(SESSION_ID, TUTOR_ID, { studentId: 'intruso', rating: 4 }),
     ).rejects.toMatchObject({ code: 'INVALID_STUDENT' });
-    expect(studentReviewRepo.upsertStudentReview).not.toHaveBeenCalled();
+    expect(studentReviewRepo.publishStudentReview).not.toHaveBeenCalled();
   });
 });
 
-describe('createStudentReview — happy path', () => {
-  it('upserts as done and recomputes the student aggregate', async () => {
+describe('createStudentReview — happy path (write-once)', () => {
+  it('publishes write-once and recomputes the student aggregate', async () => {
     sessionRepo.findById.mockResolvedValue(makeSession());
 
     const result = await service.createStudentReview(SESSION_ID, TUTOR_ID, {
@@ -110,17 +115,18 @@ describe('createStudentReview — happy path', () => {
       comment: 'Muy puntual',
     });
 
-    expect(studentReviewRepo.upsertStudentReview).toHaveBeenCalledWith({
+    expect(studentReviewRepo.publishStudentReview).toHaveBeenCalledWith({
       sessionId: SESSION_ID,
       tutorId: TUTOR_ID,
       studentId: STUDENT_ID,
       rating: 4,
-      status: 'done',
       comment: 'Muy puntual',
     });
     expect(studentReviewRepo.updateStudentRatingStats).toHaveBeenCalledWith(STUDENT_ID);
-    expect(result.updated).toBe(false);
-    expect(result.review).toMatchObject({ rating: 4, status: 'done' });
+    // The service returns ONLY a status flag — never the comment/rating back.
+    expect(result).toEqual({ status: 'done' });
+    expect(result).not.toHaveProperty('review');
+    expect(result).not.toHaveProperty('comment');
   });
 
   it('normalizes empty comment to null', async () => {
@@ -132,29 +138,25 @@ describe('createStudentReview — happy path', () => {
       comment: '',
     });
 
-    expect(studentReviewRepo.upsertStudentReview).toHaveBeenCalledWith(
+    expect(studentReviewRepo.publishStudentReview).toHaveBeenCalledWith(
       expect.objectContaining({ comment: null }),
     );
   });
 
-  it('flags updated=true when editing an already-done review', async () => {
+  it('propagates ALREADY_REVIEWED from the write-once publish (no re-rating)', async () => {
     sessionRepo.findById.mockResolvedValue(makeSession());
-    studentReviewRepo.findBySessionForTutor.mockResolvedValue([
-      { sessionId: SESSION_ID, tutorId: TUTOR_ID, studentId: STUDENT_ID, status: 'done', rating: 3 },
-    ]);
+    const err = new Error('already');
+    err.code = 'ALREADY_REVIEWED';
+    studentReviewRepo.publishStudentReview.mockRejectedValue(err);
 
-    const result = await service.createStudentReview(SESSION_ID, TUTOR_ID, {
-      studentId: STUDENT_ID,
-      rating: 5,
-    });
-
-    expect(result.updated).toBe(true);
-    expect(studentReviewRepo.updateStudentRatingStats).toHaveBeenCalledWith(STUDENT_ID);
+    await expect(
+      service.createStudentReview(SESSION_ID, TUTOR_ID, { studentId: STUDENT_ID, rating: 5 }),
+    ).rejects.toMatchObject({ code: 'ALREADY_REVIEWED' });
+    // Aggregate must NOT be recomputed when nothing was published.
+    expect(studentReviewRepo.updateStudentRatingStats).not.toHaveBeenCalled();
   });
 
   it('allows rating a session that ended but was never marked Completed', async () => {
-    // Mirrors the student→tutor flow: eligibility is "ended + not canceled",
-    // not strictly status === Completed.
     sessionRepo.findById.mockResolvedValue(makeSession({ status: 'Accepted' }));
 
     const result = await service.createStudentReview(SESSION_ID, TUTOR_ID, {
@@ -162,7 +164,7 @@ describe('createStudentReview — happy path', () => {
       rating: 4,
     });
 
-    expect(result.review.status).toBe('done');
+    expect(result).toEqual({ status: 'done' });
   });
 
   it('rates each participant independently in group sessions', async () => {
@@ -172,7 +174,7 @@ describe('createStudentReview — happy path', () => {
 
     await service.createStudentReview(SESSION_ID, TUTOR_ID, { studentId: 'b', rating: 2 });
 
-    expect(studentReviewRepo.upsertStudentReview).toHaveBeenCalledWith(
+    expect(studentReviewRepo.publishStudentReview).toHaveBeenCalledWith(
       expect.objectContaining({ studentId: 'b', rating: 2 }),
     );
     expect(studentReviewRepo.updateStudentRatingStats).toHaveBeenCalledWith('b');
@@ -180,13 +182,25 @@ describe('createStudentReview — happy path', () => {
 });
 
 describe('read helpers', () => {
-  it('getSessionStudentReviewsForTutor delegates filtered by tutor', async () => {
-    studentReviewRepo.findBySessionForTutor.mockResolvedValue([{ id: 'sr-1' }]);
+  it('getPendingStudentTargetsForTutor returns content-free status only', async () => {
+    studentReviewRepo.findStatusBySessionForTutor.mockResolvedValue([
+      { studentId: STUDENT_ID, status: 'pending' },
+    ]);
 
-    const result = await service.getSessionStudentReviewsForTutor(SESSION_ID, TUTOR_ID);
+    const result = await service.getPendingStudentTargetsForTutor(SESSION_ID, TUTOR_ID);
 
-    expect(studentReviewRepo.findBySessionForTutor).toHaveBeenCalledWith(SESSION_ID, TUTOR_ID);
-    expect(result).toEqual([{ id: 'sr-1' }]);
+    expect(studentReviewRepo.findStatusBySessionForTutor).toHaveBeenCalledWith(SESSION_ID, TUTOR_ID);
+    expect(result).toEqual([{ studentId: STUDENT_ID, status: 'pending' }]);
+    // Content-free: no rating, no comment fields ever.
+    for (const row of result) {
+      expect(row).not.toHaveProperty('rating');
+      expect(row).not.toHaveProperty('comment');
+    }
+  });
+
+  it('does not expose a tutor-facing read path for comment content', () => {
+    // The legacy comment-leaking helper must be gone from the service surface.
+    expect(service.getSessionStudentReviewsForTutor).toBeUndefined();
   });
 
   it('getOwnStudentRating returns the aggregate number only', async () => {
@@ -195,5 +209,23 @@ describe('read helpers', () => {
     const result = await service.getOwnStudentRating(STUDENT_ID);
 
     expect(result).toEqual({ average: 4.5, count: 8 });
+  });
+
+  it('getStudentReviewsReceived (admin) passes the materia filter through', async () => {
+    studentReviewRepo.findReceivedByStudent.mockResolvedValue([{ id: 'sr1', comment: 'x' }]);
+
+    const result = await service.getStudentReviewsReceived(STUDENT_ID, { courseId: 'c1', limit: 10 });
+
+    expect(studentReviewRepo.findReceivedByStudent).toHaveBeenCalledWith(STUDENT_ID, { courseId: 'c1', limit: 10 });
+    expect(result).toEqual([{ id: 'sr1', comment: 'x' }]);
+  });
+
+  it('getReviewedCoursesAsStudent delegates to the relation-based repo method', async () => {
+    studentReviewRepo.findReviewedCoursesByStudent.mockResolvedValue([{ id: 'c1', name: 'Cálculo' }]);
+
+    const result = await service.getReviewedCoursesAsStudent(STUDENT_ID);
+
+    expect(studentReviewRepo.findReviewedCoursesByStudent).toHaveBeenCalledWith(STUDENT_ID);
+    expect(result).toEqual([{ id: 'c1', name: 'Cálculo' }]);
   });
 });

--- a/src/app/api/admin/users/[userId]/student-reviews/route.js
+++ b/src/app/api/admin/users/[userId]/student-reviews/route.js
@@ -1,0 +1,53 @@
+/**
+ * GET /api/admin/users/:userId/student-reviews — Admin moderation list of the
+ * tutor→student reviews RECEIVED by a user, optionally filtered by materia.
+ *
+ * This is the ONLY read path that exposes the private comment text (tutors can
+ * never read it). Guarded by requireAdminUser.
+ *
+ * The materia filter (`?courseId=`) is resolved through the existing
+ * session→course relation — student_reviews has no course column, so the data
+ * model stays normalized (no redundant denormalized copy).
+ *
+ * Query params:
+ *   - courseId (optional): restrict to reviews whose session belongs to a materia
+ *   - limit (optional, default 50, max 100)
+ *
+ * Returns: { success, reviews, courses } where `courses` are the distinct
+ * materias the student has been reviewed in (for the filter UI).
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { requireAdminUser } from '@/lib/auth/guards';
+import * as studentReviewService from '@/lib/services/student-review.service';
+
+export async function GET(request, { params }) {
+  const auth = await requireAdminUser(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const { userId } = await params;
+  if (!userId) {
+    return NextResponse.json({ success: false, error: 'INVALID_USER_ID' }, { status: 400 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const courseId = searchParams.get('courseId') || undefined;
+  const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10) || 50, 100);
+
+  try {
+    const [reviews, courses] = await Promise.all([
+      studentReviewService.getStudentReviewsReceived(userId, { courseId, limit }),
+      studentReviewService.getReviewedCoursesAsStudent(userId),
+    ]);
+
+    return NextResponse.json({ success: true, reviews, courses });
+  } catch (err) {
+    console.error('[GET /api/admin/users/[userId]/student-reviews]', err);
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/sessions/[id]/route.js
+++ b/src/app/api/sessions/[id]/route.js
@@ -6,9 +6,12 @@
  *   - The tutor assigned to the session.
  *   - Admin users (role = 'ADMIN' in the JWT).
  *
- * Tutor-only enrichment:
- *   - participants[].student.studentRating / studentRatingCount
- *   - session.studentReviews (reviews the tutor wrote for each student)
+ * Role-scoped enrichment:
+ *   - Tutor: participants[].student.studentRating (average only, null = "Nuevo";
+ *     NO count) + session.studentReviewStatus (content-free [{studentId,status}]).
+ *     A tutor never receives rating counts nor comment text — not even their own.
+ *   - Admin: full moderation view — studentRating + studentRatingCount +
+ *     session.studentReviews (includes comments). Admin-only.
  */
 
 export const dynamic = 'force-dynamic';
@@ -41,12 +44,12 @@ export async function GET(request, { params }) {
       );
     }
 
-    // Enrich with student ratings and reviews only for the assigned tutor / admin
-    if (isTutor || isAdmin) {
-      const participantIds = (session.participants ?? [])
-        .map((p) => p.studentId)
-        .filter(Boolean);
+    const participantIds = (session.participants ?? [])
+      .map((p) => p.studentId)
+      .filter(Boolean);
 
+    if (isAdmin) {
+      // Admin moderation view: full data, including counts and comment text.
       const [ratingRows, studentReviews] = await Promise.all([
         participantIds.length > 0
           ? prisma.user.findMany({
@@ -54,9 +57,7 @@ export async function GET(request, { params }) {
               select: { id: true, studentRating: true, studentRatingCount: true },
             })
           : Promise.resolve([]),
-        prisma.studentReview.findMany({
-          where: { sessionId: id },
-        }),
+        prisma.studentReview.findMany({ where: { sessionId: id } }),
       ]);
 
       const ratingMap = Object.fromEntries(ratingRows.map((u) => [u.id, u]));
@@ -75,6 +76,41 @@ export async function GET(request, { params }) {
       });
 
       session.studentReviews = studentReviews;
+    } else if (isTutor) {
+      // Tutor view: star AVERAGE only (null = "Nuevo"; no count) and a
+      // content-free status of THIS tutor's ratings for the session. The comment
+      // text is never selected into a tutor-facing query.
+      const [ratingRows, statusRows] = await Promise.all([
+        participantIds.length > 0
+          ? prisma.user.findMany({
+              where: { id: { in: participantIds } },
+              select: { id: true, studentRating: true, studentRatingCount: true },
+            })
+          : Promise.resolve([]),
+        prisma.studentReview.findMany({
+          where: { sessionId: id, tutorId: callerId },
+          select: { studentId: true, status: true },
+        }),
+      ]);
+
+      const ratingMap = Object.fromEntries(ratingRows.map((u) => [u.id, u]));
+
+      session.participants = (session.participants ?? []).map((p) => {
+        const ratings = ratingMap[p.studentId];
+        if (!ratings) return p;
+        return {
+          ...p,
+          student: {
+            ...p.student,
+            studentRating:
+              ratings.studentRatingCount > 0 && ratings.studentRating != null
+                ? Number(ratings.studentRating)
+                : null,
+          },
+        };
+      });
+
+      session.studentReviewStatus = statusRows.map((r) => ({ studentId: r.studentId, status: r.status }));
     }
 
     return NextResponse.json({ success: true, session });

--- a/src/app/api/sessions/[id]/student-reviews/route.js
+++ b/src/app/api/sessions/[id]/student-reviews/route.js
@@ -1,12 +1,17 @@
 /**
- * POST /api/sessions/:id/student-reviews — Tutor rates a student of a finished session
- * GET  /api/sessions/:id/student-reviews — Reviews the calling tutor wrote for this session
+ * POST /api/sessions/:id/student-reviews — Tutor publishes a rating+comment for a
+ *                                          student of a finished session (write-once)
+ * GET  /api/sessions/:id/student-reviews — Content-free status of the calling
+ *                                          tutor's pending/done ratings for this session
  *
- * PRIVACY: tutor→student reviews are never public. This route only ever
- * returns reviews authored by the authenticated tutor (their own), and only
- * the session's assigned tutor can create one. Students have no read access
- * to individual reviews — they only see their aggregate via
- * GET /api/users/me/student-rating.
+ * PRIVACY / WRITE-ONLY: tutor→student reviews are never readable by tutors.
+ * - POST publishes once and is immutable afterwards (409 on a second attempt).
+ *   The response NEVER echoes the stored comment/rating — only `{ status }`.
+ * - GET returns ONLY `[{ studentId, status }]` (no rating, no comment), so the
+ *   "rate your students" UI knows who is still pending without reading content.
+ * - The review TEXT is readable solely by admins via the admin panel
+ *   (GET /api/admin/users/:id). Students see only their aggregate via
+ *   GET /api/users/me/student-rating.
  */
 
 export const dynamic = 'force-dynamic';
@@ -40,14 +45,8 @@ export async function POST(request, { params }) {
   try {
     const result = await studentReviewService.createStudentReview(sessionId, auth.sub, parsed.data);
 
-    return NextResponse.json(
-      {
-        success: true,
-        review: result.review,
-        updated: result.updated,
-      },
-      { status: result.updated ? 200 : 201 },
-    );
+    // Write-only: respond with the status only — never the stored comment/rating.
+    return NextResponse.json({ success: true, status: result.status }, { status: 201 });
   } catch (err) {
     const statusMap = {
       NOT_FOUND: 404,
@@ -56,6 +55,7 @@ export async function POST(request, { params }) {
       INVALID_RATING: 400,
       SESSION_NOT_ENDED: 422,
       SESSION_NOT_ELIGIBLE: 422,
+      ALREADY_REVIEWED: 409,
     };
 
     const status = statusMap[err.code];
@@ -76,8 +76,9 @@ export async function GET(request, { params }) {
 
   const { id: sessionId } = await params;
 
-  // Filtered by the caller's own tutorId — a tutor can only read what they wrote.
-  const reviews = await studentReviewService.getSessionStudentReviewsForTutor(sessionId, auth.sub);
+  // Content-free: only the caller's own { studentId, status } for this session.
+  // No rating, no comment ever crosses this boundary.
+  const targets = await studentReviewService.getPendingStudentTargetsForTutor(sessionId, auth.sub);
 
-  return NextResponse.json({ success: true, reviews, count: reviews.length });
+  return NextResponse.json({ success: true, targets, count: targets.length });
 }

--- a/src/app/components/SessionDetailView/SessionDetailView.jsx
+++ b/src/app/components/SessionDetailView/SessionDetailView.jsx
@@ -224,13 +224,14 @@ export default function SessionDetailView({ sessionId, session: initialSession, 
   const showActions = session?.status === 'Pending' && isTutor;
 
   // Reciprocal review state (tutor → student, only present on tutor payloads).
+  // Content-free: only { studentId, status } — never the stored rating/comment.
   // With no rows yet (sessions completed before the feature) the tutor can
   // still rate — the server creates the row on submit.
-  const studentReviews = session?.studentReviews || [];
+  const studentReviewStatus = session?.studentReviewStatus || [];
   const hasRatedAllStudents =
-    studentReviews.length > 0 &&
-    studentReviews.length >= (session?.participants?.length || 0) &&
-    studentReviews.every((r) => r.status === 'done');
+    studentReviewStatus.length > 0 &&
+    studentReviewStatus.length >= (session?.participants?.length || 0) &&
+    studentReviewStatus.every((r) => r.status === 'done');
   const canRateStudents = isTutor && session?.status === 'Completed';
 
   // ─── Render ────────────────────────────────────────────────────────────────
@@ -442,17 +443,14 @@ export default function SessionDetailView({ sessionId, session: initialSession, 
                     <div className="min-w-0">
                       <p className="font-semibold text-gray-900 truncate">{p.student?.name || 'Estudiante'}</p>
                       <p className="text-sm text-gray-500 truncate">{p.student?.email}</p>
-                      {/* Private student rating (estilo Uber) — only present on tutor payloads */}
-                      {p.student?.studentRatingCount > 0 ? (
+                      {/* Private student rating (estilo Uber) — tutors see ONLY the
+                          star average, never the count nor the comments. null = "Nuevo". */}
+                      {typeof p.student?.studentRating === 'number' ? (
                         <p className="text-xs text-gray-600 flex items-center gap-1 mt-0.5">
                           <Star className="w-3.5 h-3.5 text-yellow-500 fill-yellow-500" />
-                          <span className="font-semibold">{Number(p.student.studentRating).toFixed(1)}</span>
-                          <span className="text-gray-400">
-                            · {p.student.studentRatingCount}{' '}
-                            {p.student.studentRatingCount === 1 ? 'calificación' : 'calificaciones'}
-                          </span>
+                          <span className="font-semibold">{p.student.studentRating.toFixed(1)}</span>
                         </p>
-                      ) : p.student?.studentRatingCount === 0 ? (
+                      ) : p.student?.studentRating === null ? (
                         <span className="inline-block text-[10px] font-semibold uppercase tracking-wide bg-blue-50 text-blue-700 rounded-full px-2 py-0.5 mt-0.5">
                           Nuevo
                         </span>

--- a/src/app/components/StudentReviewModal/StudentReviewModal.css
+++ b/src/app/components/StudentReviewModal/StudentReviewModal.css
@@ -54,6 +54,16 @@
   margin-bottom: var(--space-3);
 }
 
+/* Locked state: a published rating is write-once — shown without its content. */
+.student-review-locked {
+  font-size: var(--type-caption);
+  color: var(--calico-slate-700);
+  background: var(--calico-success-soft, #ecfdf5);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  font-style: italic;
+}
+
 .student-review-block {
   margin-bottom: var(--space-3);
   text-align: left;

--- a/src/app/components/StudentReviewModal/StudentReviewModal.jsx
+++ b/src/app/components/StudentReviewModal/StudentReviewModal.jsx
@@ -31,23 +31,20 @@ export default function StudentReviewModal({ session, onClose, onSubmitted }) {
   const [showSuccess, setShowSuccess] = useState(false);
   const [error, setError] = useState(null);
 
-  // Prefill from the authoritative endpoint (covers edits after a refresh,
-  // and parents that pass a non-enriched session object).
+  // Write-only: we only learn WHICH students are already rated (status), never
+  // the stored stars/comment — those are admin-only. Done students are locked;
+  // the tutor cannot read back or edit a published rating.
   useEffect(() => {
     let cancelled = false;
     const prefill = async () => {
       if (!session?.id) return;
       const seed = {};
-      const reviews = session.studentReviews?.length
-        ? session.studentReviews
-        : await TutoringSessionService.getMyStudentReviews(session.id);
+      const targets = session.studentReviewStatus?.length
+        ? session.studentReviewStatus
+        : await TutoringSessionService.getMyStudentReviewTargets(session.id);
       if (cancelled) return;
-      for (const r of reviews || []) {
-        seed[r.studentId] = {
-          stars: r.rating || 0,
-          comment: r.comment || "",
-          wasDone: r.status === "done",
-        };
+      for (const tg of targets || []) {
+        seed[tg.studentId] = { stars: 0, comment: "", wasDone: tg.status === "done" };
       }
       setDrafts((prev) => ({ ...seed, ...prev }));
     };
@@ -77,7 +74,10 @@ export default function StudentReviewModal({ session, onClose, onSubmitted }) {
     setError(null);
 
     try {
-      const toSubmit = participants.filter((p) => (drafts[p.studentId]?.stars || 0) > 0);
+      // Never resubmit an already-published (locked) rating — it is immutable.
+      const toSubmit = participants.filter(
+        (p) => !drafts[p.studentId]?.wasDone && (drafts[p.studentId]?.stars || 0) > 0,
+      );
       for (const p of toSubmit) {
         const draft = drafts[p.studentId];
         const result = await TutoringSessionService.submitStudentReview(session.id, {
@@ -112,7 +112,6 @@ export default function StudentReviewModal({ session, onClose, onSubmitted }) {
       : session.course) || t("studentReview.defaultCourse");
 
   const singleStudent = participants.length === 1 ? participants[0]?.student : null;
-  const anyDone = participants.some((p) => drafts[p.studentId]?.wasDone);
 
   return (
     <>
@@ -131,33 +130,40 @@ export default function StudentReviewModal({ session, onClose, onSubmitted }) {
             <form onSubmit={handleSubmit}>
               {participants.map((p) => {
                 const draft = drafts[p.studentId] || { stars: 0, comment: "" };
+                const locked = !!draft.wasDone;
                 return (
                   <div key={p.studentId} className="student-review-block">
                     {!singleStudent && (
                       <p className="student-review-name">{p.student?.name || t("studentReview.fallbackStudent")}</p>
                     )}
 
-                    <div className="rating-stars student-review-stars">
-                      {[1, 2, 3, 4, 5].map((n) => (
-                        <button
-                          key={n}
-                          type="button"
-                          aria-label={`${n}/5`}
-                          onClick={() => setDraft(p.studentId, { stars: n })}
-                          className={n <= draft.stars ? "star-on" : "star-off"}
-                        >
-                          <FaStar />
-                        </button>
-                      ))}
-                    </div>
+                    {locked ? (
+                      <p className="student-review-locked">{t("studentReview.alreadyRated")}</p>
+                    ) : (
+                      <>
+                        <div className="rating-stars student-review-stars">
+                          {[1, 2, 3, 4, 5].map((n) => (
+                            <button
+                              key={n}
+                              type="button"
+                              aria-label={`${n}/5`}
+                              onClick={() => setDraft(p.studentId, { stars: n })}
+                              className={n <= draft.stars ? "star-on" : "star-off"}
+                            >
+                              <FaStar />
+                            </button>
+                          ))}
+                        </div>
 
-                    <textarea
-                      value={draft.comment}
-                      onChange={(e) => setDraft(p.studentId, { comment: e.target.value })}
-                      placeholder={t("studentReview.commentPlaceholder")}
-                      className="student-review-comment"
-                      maxLength={500}
-                    />
+                        <textarea
+                          value={draft.comment}
+                          onChange={(e) => setDraft(p.studentId, { comment: e.target.value })}
+                          placeholder={t("studentReview.commentPlaceholder")}
+                          className="student-review-comment"
+                          maxLength={500}
+                        />
+                      </>
+                    )}
                   </div>
                 );
               })}
@@ -171,8 +177,6 @@ export default function StudentReviewModal({ session, onClose, onSubmitted }) {
                 <Button type="submit" variant="tutor" disabled={ratedCount === 0 || isSubmitting}>
                   {isSubmitting
                     ? t("studentReview.buttons.saving")
-                    : anyDone
-                    ? t("studentReview.buttons.update")
                     : t("studentReview.buttons.submit")}
                 </Button>
               </div>

--- a/src/app/components/TutorApprovalModal/TutorApprovalModal.jsx
+++ b/src/app/components/TutorApprovalModal/TutorApprovalModal.jsx
@@ -80,8 +80,9 @@ export default function TutorApprovalModal({
     session.course && typeof session.course === 'object'
       ? session.course.name || session.course.code
       : session.course;
-  const ratingCount = participantStudent?.studentRatingCount;
-  const ratingAvg = Number(participantStudent?.studentRating) || 0;
+  // Pre-accept payload carries ONLY the star average (number), null for "Nuevo".
+  // The rating count and any comments never travel to the tutor.
+  const studentRating = participantStudent?.studentRating;
 
   return (
     <div className="tutor-approval-modal-overlay">
@@ -126,16 +127,13 @@ export default function TutorApprovalModal({
                 <div className="info-content">
                   <span className="info-label">Estudiante</span>
                   <span className="info-value">{studentName}</span>
-                  {/* Private student rating (visible to tutors only) */}
-                  {ratingCount > 0 ? (
+                  {/* Star average only — no count, no comments (blind acceptance) */}
+                  {typeof studentRating === 'number' ? (
                     <span className="student-rating-line">
                       <Star size={13} className="student-rating-star" />
-                      <strong>{ratingAvg.toFixed(1)}</strong>
-                      <span className="student-rating-count">
-                        · {ratingCount} {ratingCount === 1 ? 'calificación' : 'calificaciones'}
-                      </span>
+                      <strong>{studentRating.toFixed(1)}</strong>
                     </span>
-                  ) : ratingCount === 0 ? (
+                  ) : studentRating === null ? (
                     <span className="student-rating-new">Nuevo</span>
                   ) : null}
                 </div>

--- a/src/app/home/admin/users/[userId]/page.jsx
+++ b/src/app/home/admin/users/[userId]/page.jsx
@@ -72,6 +72,24 @@ function SessionItem({ s, counterpart, formatDate, t }) {
  *  - as tutor:   public student→tutor reviews (reviewer = r.student)
  *  - as student: private tutor→student reviews (reviewer = r.tutor)
  */
+function ReviewRow({ r, reviewer, starTone, formatDate }) {
+  return (
+    <li className="border border-gray-100 rounded-xl p-3">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <span className="text-sm font-medium text-gray-800 truncate">{reviewer?.name || '—'}</span>
+        <span className="inline-flex items-center gap-1 text-sm font-semibold text-gray-900">
+          <Star className={`w-3.5 h-3.5 ${starTone}`} /> {r.rating ?? '—'}
+        </span>
+      </div>
+      <div className="text-[11px] text-gray-400 mt-0.5">
+        {r.session?.course?.name || r.course?.name || ''}
+        {r.session?.startTimestamp ? ` · ${formatDate(r.session.startTimestamp)}` : ''}
+      </div>
+      {r.comment && <p className="text-sm text-gray-600 mt-1.5 whitespace-pre-line break-words">{r.comment}</p>}
+    </li>
+  );
+}
+
 function ReviewListSection({ title, subtitle, reviews, reviewerOf, starTone, formatDate }) {
   return (
     <section className="bg-white rounded-2xl border border-gray-100 p-5">
@@ -80,26 +98,84 @@ function ReviewListSection({ title, subtitle, reviews, reviewerOf, starTone, for
       </h3>
       {subtitle && <p className="text-xs text-gray-400 mb-3">{subtitle}</p>}
       <ul className="flex flex-col gap-2">
-        {reviews.map((r) => {
-          const reviewer = reviewerOf(r);
-          return (
-            <li key={r.id} className="border border-gray-100 rounded-xl p-3">
-              <div className="flex items-center justify-between gap-2 flex-wrap">
-                <span className="text-sm font-medium text-gray-800 truncate">{reviewer?.name || '—'}</span>
-                <span className="inline-flex items-center gap-1 text-sm font-semibold text-gray-900">
-                  <Star className={`w-3.5 h-3.5 ${starTone}`} /> {r.rating ?? '—'}
-                </span>
-              </div>
-              <div className="text-[11px] text-gray-400 mt-0.5">
-                {r.session?.course?.name || r.course?.name || ''}
-                {r.session?.startTimestamp ? ` · ${formatDate(r.session.startTimestamp)}` : ''}
-              </div>
-              {r.comment && <p className="text-sm text-gray-600 mt-1.5 whitespace-pre-line break-words">{r.comment}</p>}
-            </li>
-          );
-        })}
+        {reviews.map((r) => (
+          <ReviewRow key={r.id} r={r} reviewer={reviewerOf(r)} starTone={starTone} formatDate={formatDate} />
+        ))}
       </ul>
     </section>
+  );
+}
+
+/**
+ * Admin moderation of tutor→student reviews with a materia filter. The filter
+ * is resolved server-side through the session→course relation (no course column
+ * on student_reviews), so it stays normalized. This is the only surface that
+ * exposes the private comment text — already behind requireAdminUser.
+ */
+function StudentReviewsModeration({ userId, initialReviews, courses, title, subtitle, starTone, formatDate, t }) {
+  const [activeCourseId, setActiveCourseId] = useState(null);
+  const [reviews, setReviews] = useState(initialReviews || []);
+  const [loading, setLoading] = useState(false);
+
+  const filterBy = useCallback(async (courseId) => {
+    setActiveCourseId(courseId);
+    setLoading(true);
+    try {
+      const res = await AdminService.getUserStudentReviews(userId, { courseId: courseId || undefined });
+      if (res.ok && res.success) setReviews(res.reviews || []);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  return (
+    <section className="bg-white rounded-2xl border border-gray-100 p-5">
+      <h3 className="text-sm font-semibold text-gray-800 mb-1">
+        {title} <span className="text-gray-400 font-normal">({reviews.length})</span>
+      </h3>
+      {subtitle && <p className="text-xs text-gray-400 mb-3">{subtitle}</p>}
+
+      {(courses?.length || 0) > 1 && (
+        <div className="flex gap-1.5 flex-wrap mb-3">
+          <FilterChip active={!activeCourseId} disabled={loading} onClick={() => filterBy(null)}>
+            {t('admin.users.detail.studentReviews.allCourses')}
+          </FilterChip>
+          {courses.map((c) => (
+            <FilterChip key={c.id} active={activeCourseId === c.id} disabled={loading} onClick={() => filterBy(c.id)}>
+              {c.name || c.code}
+            </FilterChip>
+          ))}
+        </div>
+      )}
+
+      {reviews.length === 0 ? (
+        <p className="text-sm text-gray-400 py-3 text-center">{t('admin.users.detail.studentReviews.empty')}</p>
+      ) : (
+        <ul className={`flex flex-col gap-2 ${loading ? 'opacity-50' : ''}`}>
+          {reviews.map((r) => (
+            <ReviewRow key={r.id} r={r} reviewer={r.tutor} starTone={starTone} formatDate={formatDate} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function FilterChip({ active, disabled, onClick, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      className={`text-xs font-medium px-2.5 py-1 rounded-full border transition-colors disabled:opacity-60 ${
+        active
+          ? 'bg-sky-500 text-white border-sky-500'
+          : 'bg-white text-gray-600 border-gray-200 hover:border-sky-300 hover:text-sky-600'
+      }`}
+    >
+      {children}
+    </button>
   );
 }
 
@@ -357,13 +433,15 @@ export default function AdminUserDetailPage() {
             />
           )}
           {(data.studentReviewsReceived?.length || 0) > 0 && (
-            <ReviewListSection
+            <StudentReviewsModeration
+              userId={userId}
+              initialReviews={data.studentReviewsReceived}
+              courses={data.studentReviewCourses}
               title={t('admin.users.detail.studentReviews.title')}
               subtitle={t('admin.users.detail.studentReviews.privacy')}
-              reviews={data.studentReviewsReceived}
-              reviewerOf={(r) => r.tutor}
               starTone="text-sky-500 fill-sky-500"
               formatDate={formatDate}
+              t={t}
             />
           )}
         </div>

--- a/src/app/services/core/AdminService.js
+++ b/src/app/services/core/AdminService.js
@@ -50,6 +50,21 @@ class AdminServiceClass {
     return { ok, status, ...(data || {}) };
   }
 
+  /**
+   * Moderation list of tutor→student reviews received by a user, optionally
+   * filtered by materia (resolved server-side through the session→course
+   * relation). Admin-only; this is the only path that exposes the comment text.
+   */
+  async getUserStudentReviews(userId, { courseId } = {}) {
+    const params = new URLSearchParams();
+    if (courseId) params.set('courseId', courseId);
+    const qs = params.toString();
+    const { ok, status, data } = await authFetch(
+      `${BASE}/users/${userId}/student-reviews${qs ? `?${qs}` : ''}`,
+    );
+    return { ok, status, ...(data || {}) };
+  }
+
   // ─── Mutations ────────────────────────────────────────────────────────
 
   async approveTutor(userId, courseIds) {

--- a/src/app/services/core/TutoringSessionService.js
+++ b/src/app/services/core/TutoringSessionService.js
@@ -204,27 +204,29 @@ class TutoringSessionServiceClass {
       body: JSON.stringify(reviewData),
     });
 
+    // Write-only + write-once: the server returns only a status, never the
+    // stored comment/rating. A 409 (ALREADY_REVIEWED) means it was already
+    // published — surface it so the UI can mark that student as done.
     if (ok && data?.success) {
-      return {
-        success: true,
-        review: data.review || null,
-        updated: data.updated || false,
-      };
+      return { success: true, status: data.status || 'done' };
     }
 
     const errorMsg = data?.error || 'Failed to submit student review';
-    console.error('Error submitting student review:', errorMsg);
-    return { success: false, review: null, updated: false, error: errorMsg };
+    if (data?.code !== 'ALREADY_REVIEWED') {
+      console.error('Error submitting student review:', errorMsg);
+    }
+    return { success: false, error: errorMsg, code: data?.code || null };
   }
 
   /**
-   * Reviews the authenticated tutor wrote for a session (pending + done) —
-   * powers the rate-students modal prefill.
-   * @returns {Promise<Array>}
+   * Content-free status of the tutor's ratings for a session:
+   * `[{ studentId, status }]`. Powers the rate-students modal (which students
+   * are still pending) WITHOUT exposing any rating or comment.
+   * @returns {Promise<Array<{ studentId: string, status: string }>>}
    */
-  async getMyStudentReviews(sessionId) {
+  async getMyStudentReviewTargets(sessionId) {
     const { ok, data } = await authFetch(`${API_BASE_URL}/sessions/${sessionId}/student-reviews`);
-    if (ok && data?.success) return data.reviews || [];
+    if (ok && data?.success) return data.targets || [];
     return [];
   }
 

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1016,6 +1016,7 @@
     "fallbackStudent": "Student",
     "privacyNote": "Your rating is private: the student will never see the stars or your comment. It only feeds their overall average, visible to other tutors.",
     "commentPlaceholder": "Private comment for Calico (optional)",
+    "alreadyRated": "You already rated this student. The rating is private and cannot be edited.",
     "buttons": {
       "submit": "Submit rating",
       "update": "Update rating",
@@ -2530,7 +2531,9 @@
         },
         "studentReviews": {
           "title": "Ratings received from tutors",
-          "privacy": "Private: the student and other users never see these comments — Calico staff only."
+          "privacy": "Private: the student and other users never see these comments — Calico staff only.",
+          "allCourses": "All subjects",
+          "empty": "No ratings for this subject."
         },
         "tutorReviews": {
           "title": "Reviews received from students",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -1017,6 +1017,7 @@
     "fallbackStudent": "Estudiante",
     "privacyNote": "Tu calificación es privada: el estudiante no verá ni las estrellas ni tu comentario. Solo alimenta su promedio general, visible para otros tutores.",
     "commentPlaceholder": "Comentario privado para Calico (opcional)",
+    "alreadyRated": "Ya calificaste a este estudiante. La calificación es privada y no puede editarse.",
     "buttons": {
       "submit": "Enviar calificación",
       "update": "Actualizar calificación",
@@ -2540,7 +2541,9 @@
         },
         "studentReviews": {
           "title": "Calificaciones recibidas de tutores",
-          "privacy": "Privadas: el estudiante y otros usuarios nunca ven estos comentarios — solo el equipo de Calico."
+          "privacy": "Privadas: el estudiante y otros usuarios nunca ven estos comentarios — solo el equipo de Calico.",
+          "allCourses": "Todas las materias",
+          "empty": "Sin calificaciones para esta materia."
         },
         "tutorReviews": {
           "title": "Reseñas recibidas de estudiantes",

--- a/src/lib/repositories/student-review.repository.js
+++ b/src/lib/repositories/student-review.repository.js
@@ -3,10 +3,20 @@
  * Handles database operations for tutor→student reviews (PostgreSQL via Prisma).
  *
  * Model: StudentReview (tutorId = reviewer, studentId = reviewee, tied to a Session).
- * PRIVACY: these reviews are never public. The aggregate lives denormalized on
- * users.student_rating / users.student_rating_count (stripped from generic user
- * fetches by user.repository sanitize) and is only attached to tutor-facing
- * session payloads, the owner's own-rating endpoint, and admin views.
+ *
+ * PRIVACY MODEL (enforced at the column-selection boundary, not just the route):
+ *  - The review TEXT (`comment`) and the per-session `rating` are sensitive. They
+ *    are selected ONLY by admin-facing methods (`findReceivedByStudent`,
+ *    `findBySession`). No tutor-facing method ever projects `comment`.
+ *  - Tutor-facing reads expose ONLY `{ studentId, status }` (the "who's left to
+ *    rate" projection). This is what makes the write-only rule hold even if a
+ *    tutor crafts a request by hand: the content never leaves Postgres towards a
+ *    tutor context.
+ *  - Reviews are WRITE-ONCE: a `pending` placeholder transitions to `done`
+ *    exactly once (see {@link publishStudentReview}); a published row is immutable.
+ *  - The aggregate lives denormalized on users.student_rating /
+ *    users.student_rating_count (stripped from generic user fetches by
+ *    user.repository sanitize) and is only surfaced as a number.
  */
 
 import prisma from '../prisma';
@@ -22,7 +32,8 @@ export async function findById(id) {
 }
 
 /**
- * All student reviews for a session (admin / internal use — includes comments).
+ * All student reviews for a session (ADMIN / internal use — includes comments).
+ * Never call from a tutor-scoped path.
  */
 export async function findBySession(sessionId) {
   return prisma.studentReview.findMany({
@@ -36,41 +47,58 @@ export async function findBySession(sessionId) {
 }
 
 /**
- * Reviews written by a tutor for one session (edit prefill / pending state).
- * Safe to return to that tutor: they authored them.
+ * Content-free status projection for ONE session, scoped to the calling tutor.
+ * Returns `[{ studentId, status }]` — no rating, no comment. Powers the
+ * "which of my students are still pending to rate" UI without leaking content.
  */
-export async function findBySessionForTutor(sessionId, tutorId) {
-  return prisma.studentReview.findMany({
+export async function findStatusBySessionForTutor(sessionId, tutorId) {
+  const rows = await prisma.studentReview.findMany({
     where: { sessionId, tutorId },
+    select: { studentId: true, status: true },
     orderBy: { createdAt: 'asc' },
   });
+  return rows.map((r) => ({ studentId: r.studentId, status: r.status }));
 }
 
 /**
- * Batch variant for tutor session lists: all reviews this tutor wrote across
- * many sessions, in a single query. Returns a Map keyed by sessionId.
+ * Batch content-free status projection across many sessions for one tutor.
+ * Returns a Map keyed by sessionId → `[{ studentId, status }]`. Single query.
  */
-export async function findBySessionIdsForTutor(sessionIds, tutorId) {
+export async function findStatusBySessionIdsForTutor(sessionIds, tutorId) {
   const map = new Map();
   if (!sessionIds || sessionIds.length === 0) return map;
   const rows = await prisma.studentReview.findMany({
     where: { sessionId: { in: sessionIds }, tutorId },
+    select: { sessionId: true, studentId: true, status: true },
     orderBy: { createdAt: 'asc' },
   });
   for (const r of rows) {
     if (!map.has(r.sessionId)) map.set(r.sessionId, []);
-    map.get(r.sessionId).push(r);
+    map.get(r.sessionId).push({ studentId: r.studentId, status: r.status });
   }
   return map;
 }
 
 /**
- * Reviews received by a student (admin moderation view — includes comments,
- * tutor identity and session course).
+ * Reviews received by a student (ADMIN moderation view — includes comments,
+ * tutor identity and the session's course). Must only be called behind
+ * requireAdminUser.
+ *
+ * Optional filter by materia is applied through the EXISTING session→course
+ * relation (`session: { courseId }`) — there is no `courseId` column on
+ * student_reviews. The course is reached via the Session table, so the model
+ * stays normalized (no redundant/denormalized course copy).
+ *
+ * @param {string} studentId
+ * @param {{ limit?: number, courseId?: string }} [options]
  */
-export async function findReceivedByStudent(studentId, limit = 50) {
+export async function findReceivedByStudent(studentId, { limit = 50, courseId } = {}) {
   return prisma.studentReview.findMany({
-    where: { studentId, status: 'done' },
+    where: {
+      studentId,
+      status: 'done',
+      ...(courseId ? { session: { courseId } } : {}),
+    },
     include: {
       tutor: { select: { id: true, name: true, profilePictureUrl: true } },
       session: { select: { id: true, startTimestamp: true, course: { select: { id: true, name: true, code: true } } } },
@@ -81,38 +109,88 @@ export async function findReceivedByStudent(studentId, limit = 50) {
 }
 
 /**
- * Create or update a tutor→student review. Unlike the legacy reviews table,
- * student_reviews was born with its compound unique constraint, so we can use
- * Prisma's native atomic upsert.
+ * Distinct materias a student has been reviewed in — powers the admin
+ * moderation filter. Resolved through the session→course relation (NO
+ * denormalized course column on student_reviews), deduped in memory.
+ *
+ * @param {string} studentId
+ * @returns {Promise<Array<{ id: string, name: string, code: string }>>}
  */
-export async function upsertStudentReview({ sessionId, tutorId, studentId, rating, status, comment }) {
-  return prisma.studentReview.upsert({
-    where: {
-      sessionId_tutorId_studentId: { sessionId, tutorId, studentId },
+export async function findReviewedCoursesByStudent(studentId) {
+  const rows = await prisma.studentReview.findMany({
+    where: { studentId, status: 'done' },
+    select: {
+      session: { select: { course: { select: { id: true, name: true, code: true } } } },
     },
-    update: {
-      rating: rating ?? undefined,
-      status: status ?? undefined,
-      comment: comment ?? undefined,
-    },
-    create: {
-      sessionId,
-      tutorId,
-      studentId,
-      rating: rating ?? null,
-      status: status ?? 'pending',
-      comment: comment ?? null,
-    },
-    include: {
-      student: { select: { id: true, name: true, profilePictureUrl: true } },
-    },
+    orderBy: { createdAt: 'desc' },
   });
+
+  const seen = new Map();
+  for (const r of rows) {
+    const course = r.session?.course;
+    if (course && !seen.has(course.id)) seen.set(course.id, course);
+  }
+  return [...seen.values()];
+}
+
+/**
+ * Publish a tutor→student review WRITE-ONCE.
+ *
+ * A review is published exactly once and is then immutable:
+ *  - `pending` placeholder (created at session completion) → one-way transition
+ *    to `done` with the rating/comment.
+ *  - No placeholder (session completed before the feature existed) → insert a
+ *    fresh `done` row.
+ *  - Already `done` → throw ALREADY_REVIEWED (the tutor cannot edit, and — by the
+ *    write-only rule — cannot read back what they wrote either).
+ *
+ * Atomic + race-tolerant: the whole decision runs in a transaction and a
+ * concurrent double-publish surfaces as a unique-constraint violation (P2002),
+ * which we normalize to ALREADY_REVIEWED. Returns nothing sensitive.
+ *
+ * @returns {Promise<{ status: 'done' }>}
+ */
+export async function publishStudentReview({ sessionId, tutorId, studentId, rating, comment }) {
+  const where = { sessionId_tutorId_studentId: { sessionId, tutorId, studentId } };
+  try {
+    await prisma.$transaction(async (tx) => {
+      const existing = await tx.studentReview.findUnique({
+        where,
+        select: { id: true, status: true },
+      });
+
+      if (existing?.status === 'done') {
+        const err = new Error('Esta calificación ya fue publicada y no puede modificarse');
+        err.code = 'ALREADY_REVIEWED';
+        throw err;
+      }
+
+      if (existing) {
+        await tx.studentReview.update({
+          where,
+          data: { rating, status: 'done', comment: comment ?? null },
+        });
+      } else {
+        await tx.studentReview.create({
+          data: { sessionId, tutorId, studentId, rating, status: 'done', comment: comment ?? null },
+        });
+      }
+    });
+  } catch (err) {
+    if (err.code === 'P2002') {
+      const e = new Error('Esta calificación ya fue publicada y no puede modificarse');
+      e.code = 'ALREADY_REVIEWED';
+      throw e;
+    }
+    throw err;
+  }
+
+  return { status: 'done' };
 }
 
 /**
  * Create a pending placeholder (null rating) — used by completeSession.
- * Idempotent: if a row already exists it is left untouched (update with all
- * undefined fields is a no-op write of the same values).
+ * Idempotent: if a row already exists it is left untouched.
  */
 export async function createPendingStudentReview(sessionId, tutorId, studentId) {
   return prisma.studentReview.upsert({
@@ -127,8 +205,8 @@ export async function createPendingStudentReview(sessionId, tutorId, studentId) 
 /**
  * Recompute the student's denormalized aggregate (users.student_rating /
  * student_rating_count) from scratch inside a transaction — same proven
- * pattern as review.repository.updateTutorReviewStats, so edits stay
- * consistent under concurrency.
+ * pattern as review.repository.updateTutorReviewStats, so the write-once
+ * publish stays consistent under concurrency.
  */
 export async function updateStudentRatingStats(studentId) {
   try {

--- a/src/lib/services/admin-users.service.js
+++ b/src/lib/services/admin-users.service.js
@@ -222,6 +222,7 @@ export async function getUserProfile(userId) {
     financial,
     activityRaw,
     studentReviewsReceived,
+    studentReviewCourses,
   ] = await Promise.all([
     prisma.tutorCourse.findMany({
       where: { tutorId: id },
@@ -252,7 +253,9 @@ export async function getUserProfile(userId) {
     statsRepo.financialStats(id),
     statsRepo.monthlyActivity(id, 12),
     // Moderation view: comments included — admin-only by the route guard.
-    studentReviewRepo.findReceivedByStudent(id, 20),
+    studentReviewRepo.findReceivedByStudent(id, { limit: 20 }),
+    // Distinct materias (via session→course relation) for the moderation filter.
+    studentReviewRepo.findReviewedCoursesByStudent(id),
   ]);
 
   // Reviews received as TUTOR (the public student→tutor direction, with
@@ -269,6 +272,7 @@ export async function getUserProfile(userId) {
     sessionsAsTutor,
     sessionsAsStudent,
     studentReviewsReceived,
+    studentReviewCourses,
     tutorReviewsReceived,
     activitySeries: buildActivitySeries(activityRaw, 12),
     stats: {

--- a/src/lib/services/session.service.js
+++ b/src/lib/services/session.service.js
@@ -106,12 +106,16 @@ export async function getSessionsByTutor(tutorId, limit = 50) {
 
 /**
  * Attach tutor-only data to session payloads (PRIVATE — never call for
- * student-facing responses):
- *  - each participant's aggregate rating as a student (estilo Uber:
- *    studentRating / studentRatingCount on participant.student)
- *  - `studentReviews`: the reviews THIS tutor wrote for the session
- *    (pending placeholders + done), powering the "califica a tus
- *    estudiantes" UI state and edit prefill.
+ * student-facing responses).
+ *
+ * By business rule the tutor sees ONLY the student's star score, never the
+ * comments and never the number of ratings:
+ *  - `studentRating`: the aggregate average as a `number`, or `null` when the
+ *    student has no ratings yet (so the UI can show "Nuevo" WITHOUT leaking the
+ *    count). `studentRatingCount` is deliberately NOT exposed to tutors.
+ *  - `studentReviewStatus`: content-free `[{ studentId, status }]` — which
+ *    students this tutor still has pending to rate. NO rating, NO comment. The
+ *    review text is admin-only; the tutor cannot read back even what they wrote.
  * Two batch queries total, regardless of list size.
  */
 export async function enrichSessionsForTutor(sessions, tutorId) {
@@ -124,9 +128,9 @@ export async function enrichSessionsForTutor(sessions, tutorId) {
   ];
   const sessionIds = sessions.map((s) => s.id);
 
-  const [ratingsMap, reviewsBySession] = await Promise.all([
+  const [ratingsMap, statusBySession] = await Promise.all([
     studentReviewRepo.getStudentRatingsMap(studentIds),
-    studentReviewRepo.findBySessionIdsForTutor(sessionIds, tutorId),
+    studentReviewRepo.findStatusBySessionIdsForTutor(sessionIds, tutorId),
   ]);
 
   return sessions.map((session) => ({
@@ -137,12 +141,12 @@ export async function enrichSessionsForTutor(sessions, tutorId) {
         ...p,
         student: {
           ...p.student,
-          studentRating: rating?.average ?? 0,
-          studentRatingCount: rating?.count ?? 0,
+          // average only; null = no ratings yet ("Nuevo"). Count never travels.
+          studentRating: rating && rating.count > 0 ? rating.average : null,
         },
       };
     }),
-    studentReviews: reviewsBySession.get(session.id) || [],
+    studentReviewStatus: statusBySession.get(session.id) || [],
   }));
 }
 

--- a/src/lib/services/student-review.service.js
+++ b/src/lib/services/student-review.service.js
@@ -6,17 +6,25 @@
  * - Only sessions that already ended and were not Canceled/Rejected can be reviewed.
  * - Reviewer must be the session's assigned tutor.
  * - Reviewee must be a participant of that session.
- * - One review per (session, tutor, student) — upsert on duplicate (editable).
+ * - WRITE-ONCE: one review per (session, tutor, student), published once and then
+ *   immutable. The tutor cannot edit it and — by the write-only rule — cannot read
+ *   it back either.
  *
- * Visibility: the individual review (incl. comment) is only for the tutor who
- * wrote it and for admins. Students only ever see their aggregate number.
+ * Visibility: the individual review (rating + comment) is NEVER returned to the
+ * tutor. It is readable only by admins (moderation). Students see only their
+ * aggregate number. Tutors can only query the content-free status of which
+ * students they still have pending to rate.
  */
 
 import * as studentReviewRepo from '../repositories/student-review.repository';
 import * as sessionRepo from '../repositories/session.repository';
 
 /**
- * Create or edit a tutor→student review for a finished session.
+ * Publish a tutor→student review for a finished session (write-once).
+ * Returns only a status flag — never the stored comment/rating.
+ *
+ * @returns {Promise<{ status: 'done' }>}
+ * @throws  err.code ALREADY_REVIEWED when a published review already exists.
  */
 export async function createStudentReview(sessionId, tutorId, { studentId, rating, comment }) {
   // 0. Validate rating is in valid range (1-5)
@@ -62,19 +70,13 @@ export async function createStudentReview(sessionId, tutorId, { studentId, ratin
     throw err;
   }
 
-  // 5. Track whether this is an edit (used by the API for the status code).
-  const existing = await studentReviewRepo.findBySessionForTutor(sessionId, tutorId);
-  const wasAlreadyDone = existing.some((r) => r.studentId === studentId && r.status === 'done');
-
-  // 6. Upsert with rating and mark as done, then recompute the student's
-  // denormalized aggregate (transactional, recomputed from scratch so edits
-  // stay consistent).
-  const review = await studentReviewRepo.upsertStudentReview({
+  // 5. Publish write-once (throws ALREADY_REVIEWED if previously published),
+  // then recompute the student's denormalized aggregate.
+  const result = await studentReviewRepo.publishStudentReview({
     sessionId,
     tutorId,
     studentId,
     rating,
-    status: 'done',
     comment: comment || null,
   });
 
@@ -83,15 +85,16 @@ export async function createStudentReview(sessionId, tutorId, { studentId, ratin
   // Deliberately NO notification to the student: the per-session rating is
   // private (Uber-style). The student only ever sees their aggregate.
 
-  return { review, updated: wasAlreadyDone };
+  return result; // { status: 'done' }
 }
 
 /**
- * Reviews the tutor wrote for one session (pending placeholders + done) —
- * powers the "rate your students" UI state and edit prefill.
+ * Content-free list of the tutor's rating status for a session:
+ * `[{ studentId, status }]`. Powers the "rate your students" UI (which students
+ * remain pending) WITHOUT exposing any rating or comment. Safe for tutors.
  */
-export async function getSessionStudentReviewsForTutor(sessionId, tutorId) {
-  return studentReviewRepo.findBySessionForTutor(sessionId, tutorId);
+export async function getPendingStudentTargetsForTutor(sessionId, tutorId) {
+  return studentReviewRepo.findStatusBySessionForTutor(sessionId, tutorId);
 }
 
 /**
@@ -104,8 +107,21 @@ export async function getOwnStudentRating(userId) {
 
 /**
  * Admin moderation view: reviews received by a student, including comments
- * and tutor identity. Must only be called behind requireAdminUser.
+ * and tutor identity. Optionally filtered by materia through the session→course
+ * relation (normalized — no course column on student_reviews). Must only be
+ * called behind requireAdminUser.
+ *
+ * @param {string} studentId
+ * @param {{ courseId?: string, limit?: number }} [options]
  */
-export async function getStudentReviewsReceived(studentId, limit = 50) {
-  return studentReviewRepo.findReceivedByStudent(studentId, limit);
+export async function getStudentReviewsReceived(studentId, { courseId, limit = 50 } = {}) {
+  return studentReviewRepo.findReceivedByStudent(studentId, { courseId, limit });
+}
+
+/**
+ * Distinct materias a student has been reviewed in — for the admin filter.
+ * Admin-only. Resolved via the session→course relation.
+ */
+export async function getReviewedCoursesAsStudent(studentId) {
+  return studentReviewRepo.findReviewedCoursesByStudent(studentId);
 }


### PR DESCRIPTION
## Contexto
Implementa las reglas de negocio acordadas en equipo sobre los comentarios recíprocos tutor↔estudiante. **No requiere migración de base de datos** (se apoya en el campo `status` y en relaciones existentes).

## Reglas implementadas
1. **Comentarios write-only**: el tutor publica calificación+comentario sobre el estudiante pero **no puede leerlos** después — ni siquiera los que él mismo escribió.
2. **Write-once**: una calificación se publica una sola vez y queda inmutable (`409 ALREADY_REVIEWED` al reintentar). Se acabó la edición.
3. **Lectura solo admin**: el texto de los comentarios solo es legible por administradores, desde el panel.
4. **Aceptación a ciegas parcial**: antes de aceptar, el tutor recibe **solo el promedio de estrellas** del estudiante (number o `null`="Nuevo"). No viajan el conteo de calificaciones ni los comentarios.

## Cambios principales
**Backend**
- `student-review.repository`: nuevo `publishStudentReview` write-once (transición atómica `pending→done`, tolerante a P2002). Métodos de contexto-tutor (`findStatusBySessionForTutor/...IdsForTutor`) seleccionan **solo `{studentId,status}`** — el `comment` nunca se proyecta hacia un tutor. Eliminados los métodos que filtraban contenido al tutor.
- `student-review.service` / rutas: el POST responde `{success,status}` (sin eco del comentario); `GET /api/sessions/:id/student-reviews` devuelve `targets [{studentId,status}]`.
- `session.service` + `GET /api/sessions/:id`: enrichment **role-scoped** — tutor recibe `studentRating` (promedio, `null`="Nuevo") y `studentReviewStatus` content-free; admin mantiene la vista completa (count + comentarios).

**Frontend**
- `StudentReviewModal`, `SessionDetailView`, `TutorApprovalModal`: solo muestran el promedio; los estudiantes ya calificados quedan **bloqueados** sin exponer el contenido. i18n es/en añadido.

**Admin — filtro por materia (normalizado)**
- Sin columna redundante: el filtro se resuelve por la relación existente `session → course` (`where: { session: { courseId } }`).
- Nuevo endpoint `GET /api/admin/users/[userId]/student-reviews?courseId=` (tras `requireAdminUser`) — único camino que expone el texto.
- UI: chips de materia en el detalle de usuario admin.

## Seguridad / privacidad
La regla write-only se hace cumplir en el **límite de acceso a datos** (las queries de contexto-tutor no seleccionan `comment`), no solo en el front. El texto solo sale de Postgres hacia un contexto admin.

## Notas
- Inmutabilidad de sesiones (regla 1) ya estaba garantizada a nivel API (no existe PATCH/DELETE de sesión). El bucle de corrección self-service (reject-with-reason + rebooking) queda como follow-up del módulo de booking.

## Testing
- ✅ Suite completa **749/749** verde (59 suites).
- Reescritos `student-review.service.test.js` y `student-reviews.api.test.js` (write-once, no-echo, lecturas content-free, promedio null-aware).
- Nuevo `admin-student-reviews.api.test.js` (filtro por relación, sin columna `courseId`; admin sí lee comentarios).
