### PR TITLE
fix/calico-calendar-token-health-check

### DIFF
--- a/docs/ops/calendar-token-monitor.md
+++ b/docs/ops/calendar-token-monitor.md
@@ -1,0 +1,121 @@
+# Calico Calendar admin-token monitor
+
+The central Calico calendar authenticates with a Google OAuth **admin refresh
+token** (`GOOGLE_ADMIN_REFRESH_TOKEN`). As long as the OAuth consent screen is
+published **"In production"** the token is long-lived, but it can still die
+(revoked, app flipped back to "Testing", or ~6 months unused). When it dies,
+session bookings silently lose their Google Meet link — a client-facing
+failure.
+
+This monitor catches that **before a client hits it**: an external Google Apps
+Script pings the app's health endpoint every hour and emails the team if the
+token stops working (or the app is unreachable).
+
+## How it works
+
+```
+Apps Script (hourly trigger)  ──GET──▶  /api/calico-calendar/status
+        │                                   (verifyConnection: live probe)
+        └─ connected !== true  ──▶  MailApp.sendEmail(team)
+```
+
+- **Data source:** `GET /api/calico-calendar/status` returns
+  `{ configured, connected, reason, message }`. `connected` comes from a real
+  Google Calendar API call (`verifyConnection` in
+  `src/lib/services/calico-calendar.service.js`), not just an env-var check.
+- **Trigger + alert:** the Apps Script below. It runs on Google's infra, so it
+  also alerts if the CalicoPage app itself is down.
+- **No spam:** it only emails on a state change (healthy → broken) and again on
+  recovery (broken → healthy), tracked via Script Properties.
+
+## Setup (once)
+
+1. Go to [script.google.com](https://script.google.com) → **New project**.
+2. Paste `monitor.gs` (below) and edit `CONFIG`:
+   - `STATUS_URL` → production URL, e.g. `https://app.calico.../api/calico-calendar/status`
+   - `ALERT_RECIPIENTS` → comma-separated team emails.
+3. Run `installHourlyTrigger` once and authorize when prompted.
+4. Done — `checkCalendarToken` now runs every hour. Use the script's
+   **Executions** tab to confirm it's firing.
+
+## monitor.gs
+
+```javascript
+/**
+ * Calico — Google Calendar admin-token monitor.
+ * Hourly health check against the CalicoPage status endpoint; emails the team
+ * when the central-calendar token is dead or the app is unreachable.
+ */
+const CONFIG = {
+  // Production health endpoint (added by the fix branch).
+  STATUS_URL: 'https://TU-DOMINIO/api/calico-calendar/status',
+  // Who gets alerted (comma-separated).
+  ALERT_RECIPIENTS: 'calico-tutorias@gmail.com',
+};
+
+function checkCalendarToken() {
+  const props = PropertiesService.getScriptProperties();
+  // Optimistic default so the first broken check always alerts.
+  const wasHealthy = props.getProperty('lastHealthy') !== 'false';
+
+  let healthy = false;
+  let detail = '';
+
+  try {
+    const res = UrlFetchApp.fetch(CONFIG.STATUS_URL, { muteHttpExceptions: true });
+    const code = res.getResponseCode();
+    if (code === 200) {
+      const data = JSON.parse(res.getContentText());
+      healthy = data.connected === true;
+      detail = data.message || JSON.stringify(data);
+    } else {
+      detail = `Health endpoint returned HTTP ${code}: ${res.getContentText().slice(0, 300)}`;
+    }
+  } catch (err) {
+    detail = `Could not reach health endpoint: ${err}`;
+  }
+
+  if (!healthy && wasHealthy) {
+    MailApp.sendEmail({
+      to: CONFIG.ALERT_RECIPIENTS,
+      subject: '🔴 Calico: el token del Google Calendar central dejó de funcionar',
+      body:
+        'El monitor detectó que el calendario central de Calico no está conectado.\n\n' +
+        'Detalle:\n' + detail + '\n\n' +
+        'Acción: regenera GOOGLE_ADMIN_REFRESH_TOKEN (OAuth Playground) y verifica ' +
+        'que la app OAuth siga "In production".\n\n' +
+        'Endpoint revisado: ' + CONFIG.STATUS_URL,
+    });
+  } else if (healthy && !wasHealthy) {
+    MailApp.sendEmail({
+      to: CONFIG.ALERT_RECIPIENTS,
+      subject: '🟢 Calico: el token del Google Calendar central se recuperó',
+      body: 'El calendario central volvió a conectar correctamente.\n\n' + detail,
+    });
+  }
+
+  props.setProperty('lastHealthy', String(healthy));
+}
+
+function installHourlyTrigger() {
+  ScriptApp.getProjectTriggers()
+    .filter((t) => t.getHandlerFunction() === 'checkCalendarToken')
+    .forEach((t) => ScriptApp.deleteTrigger(t));
+  ScriptApp.newTrigger('checkCalendarToken').timeBased().everyHours(1).create();
+}
+```
+
+## Notes
+
+- The status endpoint is currently **public** (returns only health booleans, no
+  secrets/PII). If you want it locked down, guard it with `requireAdminSecret`
+  and send the `x-admin-secret` header from the Apps Script.
+- **Alternative trigger:** a GitHub Actions scheduled workflow (`on: schedule`)
+  hitting the same endpoint also works, but it lives in CI rather than as an
+  independent monitor and would email via a separate channel.
+- **Fully independent variant:** instead of pinging the app, the Apps Script can
+  test the refresh token directly against `https://oauth2.googleapis.com/token`
+  (grant_type=refresh_token) with the client id/secret/refresh token stored in
+  Script Properties. More robust (works even mid-deploy) but duplicates the
+  refresh token, so it must be updated whenever the token is rotated.
+```

--- a/src/app/api/calico-calendar/status/route.js
+++ b/src/app/api/calico-calendar/status/route.js
@@ -11,13 +11,26 @@ import * as calicoCalendarService from '../../../../lib/services/calico-calendar
  */
 export async function GET(request) {
   try {
-    const isConfigured = calicoCalendarService.isConfigured();
-    
+    const status = await calicoCalendarService.verifyConnection();
+
+    let message;
+    if (!status.configured) {
+      message =
+        'Calico Calendar service is not configured. Set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_ADMIN_REFRESH_TOKEN and CALICO_CALENDAR_ID in .env';
+    } else if (status.connected) {
+      message = 'Calico Calendar service is ready';
+    } else if (status.reason === 'token_expired') {
+      message =
+        'Calico Calendar admin token is expired or revoked. Regenerate GOOGLE_ADMIN_REFRESH_TOKEN and make sure the OAuth consent screen is published "In production" so the new token does not expire.';
+    } else {
+      message = 'Calico Calendar service error: could not reach Google Calendar.';
+    }
+
     return NextResponse.json({
-      configured: isConfigured,
-      message: isConfigured
-        ? 'Calico Calendar service is ready'
-        : 'Calico Calendar service is not configured. Set GOOGLE_SERVICE_ACCOUNT_KEY and CALICO_CALENDAR_ID in .env',
+      configured: status.configured,
+      connected: status.connected,
+      reason: status.reason,
+      message,
     });
   } catch (error) {
     console.error('Error checking Calico Calendar status:', error);

--- a/src/lib/services/calico-calendar.service.js
+++ b/src/lib/services/calico-calendar.service.js
@@ -1,7 +1,12 @@
 /**
  * Calico Calendar Service
- * Manages the central Calico calendar using Google Service Account
- * Creates tutoring session events with Google Meet integration
+ * Manages the central Calico calendar via an OAuth2 admin refresh token
+ * (GOOGLE_ADMIN_REFRESH_TOKEN). Creates tutoring session events with Google
+ * Meet integration.
+ *
+ * NOTE: the refresh token only stays valid long-term while the OAuth consent
+ * screen is published "In production". In "Testing" mode Google expires it
+ * after ~7 days, which forces a manual regeneration.
  */
 
 import { google } from 'googleapis';
@@ -39,7 +44,9 @@ export async function initializeAuth() {
       'https://developers.google.com/oauthplayground'
     );
 
-    // Configuramos el cliente con el token permanente
+    // The googleapis client auto-refreshes the short-lived access token from
+    // this refresh token on every call. The refresh token itself only dies if
+    // it is revoked or the OAuth app drops back to "Testing" mode.
     oauth2Client.setCredentials({
       refresh_token: refreshToken
     });
@@ -81,6 +88,43 @@ export async function getCalendarClient() {
  */
 export function isConfigured() {
   return !!(auth && calendarId);
+}
+
+/**
+ * Actively verify the admin refresh token still works.
+ *
+ * `isConfigured()` only checks that env vars are present — it returns true even
+ * with an expired/revoked token, so failures stay silent until event creation.
+ * This performs a lightweight live call so a dead token is detected up front.
+ *
+ * @returns {Promise<{ configured: boolean, connected: boolean, reason: string|null }>}
+ */
+export async function verifyConnection() {
+  if (!auth) {
+    await initializeAuth();
+  }
+
+  if (!auth || !calendarId) {
+    return { configured: false, connected: false, reason: 'not_configured' };
+  }
+
+  try {
+    const calendar = google.calendar({ version: 'v3', auth });
+    await calendar.calendarList.list({ maxResults: 1 });
+    return { configured: true, connected: true, reason: null };
+  } catch (error) {
+    const message = error?.message || '';
+    const isAuthError =
+      error?.code === 400 ||
+      error?.code === 401 ||
+      /invalid_grant|invalid_token|unauthorized/i.test(message);
+    console.warn(` Calico Calendar token check failed: ${message}`);
+    return {
+      configured: true,
+      connected: false,
+      reason: isAuthError ? 'token_expired' : 'unknown_error',
+    };
+  }
 }
 
 /**
@@ -510,6 +554,7 @@ initializeAuth().catch((error) => {
 export default {
   initializeAuth,
   isConfigured,
+  verifyConnection,
   createTutoringSessionEvent,
   updateTutoringSessionEvent,
   cancelTutoringSessionEvent,


### PR DESCRIPTION
## Problem

The central Calico calendar authenticates with an OAuth **admin refresh token** (`GOOGLE_ADMIN_REFRESH_TOKEN`). The token was expiring ~weekly because the Google OAuth consent screen had been flipped back to **"Testing"** mode (7-day refresh-token expiry). That root cause is fixed in the Google Cloud Console by republishing the app **"In production"** — no code needed for that part.

The remaining code problem: `isConfigured()` only checked that env vars are present, so an **expired/revoked token still reported "ready"** and session bookings silently lost their Google Meet link — a client-facing failure with no signal.

## Changes

- **`verifyConnection()`** in `calico-calendar.service.js`: a lightweight live Google Calendar probe that classifies the token as `connected` / `token_expired` / `not_configured`.
- **`GET /api/calico-calendar/status`** now returns the real `connected` state plus `reason` and an actionable `message`. Backward compatible — keeps the existing `configured` field.
- Corrected the misleading *"permanent token"* / *"Service Account"* comments (it's OAuth2 + refresh token, only long-lived while the app stays "In production").
- **`docs/ops/calendar-token-monitor.md`**: a Google Apps Script that pings the health endpoint hourly and emails the team on failure (and on recovery), so a dead token is caught before a client hits it.

## Verification

- `eslint` on the changed files: 0 errors (one pre-existing anonymous-default-export warning, untouched).
- `booking-create-session` suite (exercises the calendar flow) passes. The other two suites fail only at import time due to missing AWS env in the bare checkout — unrelated to this change.

https://claude.ai/code/session_01VobEtfqAzq6gpPVZxfRpKh