### PR TITLE
Feature/documentation db test

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ cd calico-monitorias
 pnpm install
 
 # Setup environment
-cp .env.example .env.local
-# Edit .env.local with your credentials (see docs/specs/technical.md for all vars)
+# For local development, use a personal local PostgreSQL DB.
+# Follow docs/LOCAL_DATABASE.md to create .env.local and start Postgres.
 
 # Run development server
 pnpm dev
@@ -105,6 +105,7 @@ pnpm db:seed          # Seed departments and careers
 | File | Content |
 |---|---|
 | [docs/PROJECT.md](docs/PROJECT.md) | Product overview, user flows, pricing model, cancellation policy |
+| [docs/LOCAL_DATABASE.md](docs/LOCAL_DATABASE.md) | Local PostgreSQL setup for each developer |
 | [docs/PATTERNS.md](docs/PATTERNS.md) | Architecture, conventions, auth, design system, i18n rules |
 | [docs/specs/functional.md](docs/specs/functional.md) | Detailed user flows and business rules |
 | [docs/specs/technical.md](docs/specs/technical.md) | DB schema, all API routes, env vars, external services |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: calico-postgres-local
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: calico
+      POSTGRES_PASSWORD: calico
+      POSTGRES_DB: calico_local
+    ports:
+      - "5432:5432"
+    volumes:
+      - calico_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U calico -d calico_local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  calico_postgres_data:

--- a/docs/LOCAL_DATABASE.md
+++ b/docs/LOCAL_DATABASE.md
@@ -113,6 +113,12 @@ Make sure Docker Desktop is running before continuing.
    docker compose up -d postgres
    ```
 
+   If your Docker installation does not recognize `docker compose`, use the legacy command:
+
+   ```bash
+   docker-compose up -d postgres
+   ```
+
 3. Create `.env.local` in the project root:
 
    ```bash
@@ -200,6 +206,8 @@ colima start
 docker compose up -d postgres
 ```
 
+If your Docker CLI does not support `docker compose`, use `docker-compose` in the commands above.
+
 Start the app:
 
 ```bash
@@ -225,6 +233,15 @@ This deletes only your local Docker database volume.
 ```bash
 docker compose down -v
 docker compose up -d postgres
+pnpm db:push
+pnpm db:seed
+```
+
+Legacy Docker Compose equivalent:
+
+```bash
+docker-compose down -v
+docker-compose up -d postgres
 pnpm db:push
 pnpm db:seed
 ```

--- a/docs/LOCAL_DATABASE.md
+++ b/docs/LOCAL_DATABASE.md
@@ -1,0 +1,267 @@
+# Local Database Setup
+
+This project should be developed against a personal local PostgreSQL database. Do not point local development to the shared AWS RDS production database.
+
+Production and preview environment variables live in Vercel, so local changes to `.env.local` do not affect deployed environments.
+
+## Goal
+
+Each developer gets:
+
+- A private PostgreSQL container on their machine.
+- A local `.env.local` file pointing to that database.
+- A schema created from `prisma/schema.prisma`.
+- Optional seed data for local testing.
+
+## Prerequisites
+
+### macOS with Docker Desktop
+
+Install these once:
+
+```bash
+brew install node
+brew install --cask docker
+```
+
+Enable `pnpm` through Corepack:
+
+```bash
+corepack enable
+corepack prepare pnpm@10.33.4 --activate
+pnpm --version
+```
+
+If `corepack` is not found after installing Node with Homebrew, run it directly:
+
+```bash
+/opt/homebrew/bin/corepack enable
+/opt/homebrew/bin/corepack prepare pnpm@10.33.4 --activate
+```
+
+Then make sure Docker Desktop is open.
+
+### macOS with Colima
+
+If you use Colima instead of Docker Desktop, install the Docker CLI and Colima:
+
+```bash
+brew install node
+brew install docker docker-compose colima
+```
+
+Start Colima before running any Docker commands:
+
+```bash
+colima start
+docker context use colima
+docker ps
+```
+
+Then enable `pnpm` through Corepack:
+
+```bash
+corepack enable
+corepack prepare pnpm@10.33.4 --activate
+pnpm --version
+```
+
+If `corepack` is not found after installing Node with Homebrew, run it directly:
+
+```bash
+/opt/homebrew/bin/corepack enable
+/opt/homebrew/bin/corepack prepare pnpm@10.33.4 --activate
+```
+
+### Windows
+
+Recommended setup:
+
+1. Install Docker Desktop for Windows.
+2. Enable WSL 2 when Docker asks for it.
+3. Install Node.js from `https://nodejs.org/`.
+4. Open PowerShell, Windows Terminal, or a WSL terminal.
+
+Enable `pnpm`:
+
+```powershell
+corepack enable
+corepack prepare pnpm@10.33.4 --activate
+pnpm --version
+```
+
+If `corepack` is not found on Windows, close and reopen the terminal after installing Node. If it still does not appear, install `pnpm` directly:
+
+```powershell
+npm install -g pnpm@10.33.4
+pnpm --version
+```
+
+Make sure Docker Desktop is running before continuing.
+
+## First-Time Setup
+
+1. Install dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Start the local database:
+
+   ```bash
+   docker compose up -d postgres
+   ```
+
+3. Create `.env.local` in the project root:
+
+   ```bash
+   DATABASE_URL="postgresql://calico:calico@localhost:5432/calico_local"
+   DATABASE_SSL_REJECT_UNAUTHORIZED=false
+
+   JWT_SECRET="local-dev-secret-change-me-local-only"
+   JWT_EXPIRATION=7d
+
+   NEXT_PUBLIC_APP_URL=http://localhost:3000
+   NEXT_PUBLIC_FRONTEND_URL=http://localhost:3000
+   ```
+
+   Add any integration-specific secrets only when you need that feature locally, for example Wompi, Google Calendar, Brevo, or S3.
+
+   If you prefer to reuse an existing `.env` file instead of creating `.env.local`, make a private backup first:
+
+   ```bash
+   cp .env .env.remote.backup
+   ```
+
+   Then replace only the local development values in `.env`, especially `DATABASE_URL`. Restore the backup only when you intentionally need to point local code at the remote environment.
+
+4. Generate the Prisma client:
+
+   ```bash
+   pnpm db:generate
+   ```
+
+5. Create/update the local database schema:
+
+   ```bash
+   pnpm db:push
+   ```
+
+   Use `db:push` for now. The migration history currently cannot bootstrap a fresh database cleanly; see `docs/BACKLOG.md`.
+
+6. Seed local reference data:
+
+   ```bash
+   pnpm db:seed
+   ```
+
+   Optional: add fake users, tutors, sessions, reviews, payments, and admin data for UI testing:
+
+   ```bash
+   pnpm db:seed:test
+   ```
+
+   The testing seed creates these local-only accounts:
+
+   ```txt
+   admin.test@calico.local         / CalicoTest123!
+   student.test@calico.local       / CalicoTest123!
+   tutor.test@calico.local         / CalicoTest123!
+   pending.tutor.test@calico.local / CalicoTest123!
+   ```
+
+   The admin account has `ADMIN` role and is also an approved tutor, so it can be used to test privileged admin screens and tutor flows.
+
+7. Start the app:
+
+   ```bash
+   pnpm dev
+   ```
+
+8. Open:
+
+   ```txt
+   http://localhost:3000
+   ```
+
+## Daily Workflow
+
+Start the database:
+
+```bash
+docker compose up -d postgres
+```
+
+If you are on macOS with Colima, make sure Colima is running first:
+
+```bash
+colima start
+docker compose up -d postgres
+```
+
+Start the app:
+
+```bash
+pnpm dev
+```
+
+Open Prisma Studio when you want to inspect or edit local data:
+
+```bash
+pnpm db:studio
+```
+
+Stop the database without deleting data:
+
+```bash
+docker compose stop postgres
+```
+
+## Reset Your Local Database
+
+This deletes only your local Docker database volume.
+
+```bash
+docker compose down -v
+docker compose up -d postgres
+pnpm db:push
+pnpm db:seed
+```
+
+## Environment Rules
+
+- Local development uses `.env.local`.
+- Vercel deployments use Vercel environment variables.
+- Never use the production AWS RDS `DATABASE_URL` in `.env.local`.
+- Never commit `.env.local`; `.env*` is already ignored by `.gitignore`.
+- If you need shared testing data, export/import a sanitized dump instead of connecting everyone to the same database.
+
+## Troubleshooting
+
+If port `5432` is already in use, either stop the other PostgreSQL service or change the compose port to another local port, for example:
+
+```yaml
+ports:
+  - "5433:5432"
+```
+
+Then use:
+
+```bash
+DATABASE_URL="postgresql://calico:calico@localhost:5433/calico_local"
+```
+
+If the app still shows old Prisma or Next errors after config changes:
+
+```bash
+rm -rf .next
+pnpm dev
+```
+
+If Prisma cannot connect, check the container:
+
+```bash
+docker compose ps
+docker compose logs postgres
+```

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "db:push": "pnpm exec prisma db push",
     "db:studio": "pnpm exec prisma studio",
     "db:seed": "node prisma/seed.js",
+    "db:seed:test": "node prisma/seed-testing.js",
     "postinstall": "prisma generate"
   },
   "devDependencies": {

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,5 +1,8 @@
-import "dotenv/config";
+import * as dotenv from "dotenv";
 import { defineConfig } from "prisma/config";
+
+dotenv.config({ path: ".env.local" });
+dotenv.config();
 
 function isLocalDatabase(url?: string) {
   if (!url) return false;

--- a/prisma/seed-testing.js
+++ b/prisma/seed-testing.js
@@ -1,0 +1,555 @@
+/**
+ * Testing seed for local development.
+ *
+ * Run after `pnpm db:push`:
+ *   pnpm db:seed:test
+ *
+ * This file intentionally creates fake local-only users and activity for UI
+ * testing. Never run it against production or shared remote databases.
+ */
+
+require('dotenv').config({ path: '.env.local' });
+require('dotenv').config();
+const bcrypt = require('bcrypt');
+const { Pool } = require('pg');
+const { PrismaPg } = require('@prisma/adapter-pg');
+const { PrismaClient } = require('../src/generated/prisma');
+
+function createClient() {
+  const url = new URL(process.env.DATABASE_URL);
+  const pool = new Pool({
+    host: url.hostname,
+    port: parseInt(url.port) || 5432,
+    database: url.pathname.slice(1).split('?')[0],
+    user: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+    ssl: url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+      ? false
+      : { rejectUnauthorized: false },
+  });
+  return new PrismaClient({ adapter: new PrismaPg(pool) });
+}
+
+const prisma = createClient();
+
+const TEST_PASSWORD = 'CalicoTest123!';
+const TEST_IDS = {
+  admin: '00000000-0000-4000-8000-000000000001',
+  student: '00000000-0000-4000-8000-000000000002',
+  tutor: '00000000-0000-4000-8000-000000000003',
+  pendingTutor: '00000000-0000-4000-8000-000000000004',
+  suspendedTutor: '00000000-0000-4000-8000-000000000005',
+  completedSession: '00000000-0000-4000-8000-000000000101',
+  upcomingSession: '00000000-0000-4000-8000-000000000102',
+  pendingSession: '00000000-0000-4000-8000-000000000103',
+};
+
+const requiredCareers = [
+  { code: 'ISIS', name: 'Ingeniería de Sistemas y Computación' },
+  { code: 'MATE', name: 'Matemáticas' },
+  { code: 'IIND', name: 'Ingeniería Industrial' },
+];
+
+const requiredCourses = [
+  {
+    code: 'ISIS1221',
+    name: 'Introducción a la Programación',
+    basePrice: 35000,
+    complexity: 'Introductory',
+    aliases: ['IP'],
+    careerCode: 'ISIS',
+  },
+  {
+    code: 'ISIS1225',
+    name: 'Estructuras de Datos y Algoritmos',
+    basePrice: 45000,
+    complexity: 'Foundational',
+    aliases: ['EDA'],
+    careerCode: 'ISIS',
+  },
+  {
+    code: 'MATE1203',
+    name: 'Cálculo Diferencial',
+    basePrice: 35000,
+    complexity: 'Foundational',
+    aliases: [],
+    careerCode: 'MATE',
+  },
+  {
+    code: 'IIND2106',
+    name: 'Probabilidad y Estadística',
+    basePrice: 45000,
+    complexity: 'Foundational',
+    aliases: [],
+    careerCode: 'IIND',
+  },
+];
+
+function hoursFromNow(hours) {
+  return new Date(Date.now() + hours * 60 * 60 * 1000);
+}
+
+function timeOnly(hour, minute = 0) {
+  return new Date(Date.UTC(1970, 0, 1, hour, minute, 0));
+}
+
+async function ensureAcademicData() {
+  for (const career of requiredCareers) {
+    await prisma.career.upsert({
+      where: { code: career.code },
+      update: { name: career.name },
+      create: career,
+    });
+  }
+
+  const careers = await prisma.career.findMany({
+    where: { code: { in: requiredCareers.map((career) => career.code) } },
+    select: { id: true, code: true },
+  });
+  const careerIdByCode = new Map(careers.map((career) => [career.code, career.id]));
+
+  for (const course of requiredCourses) {
+    const { careerCode, ...courseData } = course;
+    await prisma.course.upsert({
+      where: { code: course.code },
+      update: { ...courseData, careerId: careerIdByCode.get(careerCode) },
+      create: { ...courseData, careerId: careerIdByCode.get(careerCode) },
+    });
+  }
+}
+
+async function upsertUser({ id, email, name, role = 'STUDENT', careerId, ...data }) {
+  const passwordHash = await bcrypt.hash(TEST_PASSWORD, 10);
+  return prisma.user.upsert({
+    where: { email },
+    update: {
+      id,
+      name,
+      role,
+      careerId,
+      passwordHash,
+      authProvider: 'Local',
+      isActive: true,
+      isEmailVerified: true,
+      terms: true,
+      ...data,
+    },
+    create: {
+      id,
+      email,
+      name,
+      role,
+      careerId,
+      passwordHash,
+      authProvider: 'Local',
+      isActive: true,
+      isEmailVerified: true,
+      terms: true,
+      ...data,
+    },
+  });
+}
+
+async function ensureTutorProfile(user, profileData, tutorCourses) {
+  await prisma.tutorProfile.upsert({
+    where: { userId: user.id },
+    update: profileData,
+    create: { userId: user.id, ...profileData },
+  });
+
+  await prisma.schedule.upsert({
+    where: { userId: user.id },
+    update: {
+      timezone: 'America/Bogota',
+      autoAcceptSession: false,
+      minBookingNotice: 12,
+      maxSessionsPerDay: 4,
+      bufferTime: 15,
+    },
+    create: {
+      userId: user.id,
+      timezone: 'America/Bogota',
+      autoAcceptSession: false,
+      minBookingNotice: 12,
+      maxSessionsPerDay: 4,
+      bufferTime: 15,
+    },
+  });
+
+  await prisma.availability.deleteMany({ where: { userId: user.id } });
+  await prisma.availability.createMany({
+    data: [
+      { userId: user.id, dayOfWeek: 1, startTime: timeOnly(14), endTime: timeOnly(16), label: 'Testing lunes tarde' },
+      { userId: user.id, dayOfWeek: 3, startTime: timeOnly(9), endTime: timeOnly(11), label: 'Testing miércoles mañana' },
+      { userId: user.id, dayOfWeek: 5, startTime: timeOnly(15), endTime: timeOnly(18), label: 'Testing viernes tarde' },
+    ],
+  });
+
+  for (const tutorCourse of tutorCourses) {
+    await prisma.tutorCourse.upsert({
+      where: { tutorId_courseId: { tutorId: user.id, courseId: tutorCourse.courseId } },
+      update: {
+        status: tutorCourse.status,
+        experience: tutorCourse.experience,
+        workSampleUrl: tutorCourse.workSampleUrl,
+      },
+      create: {
+        tutorId: user.id,
+        courseId: tutorCourse.courseId,
+        status: tutorCourse.status,
+        experience: tutorCourse.experience,
+        workSampleUrl: tutorCourse.workSampleUrl,
+      },
+    });
+  }
+}
+
+async function main() {
+  const dbHost = new URL(process.env.DATABASE_URL).hostname;
+  if (!['localhost', '127.0.0.1', '::1'].includes(dbHost)) {
+    throw new Error(`Refusing to run testing seed against non-local database host: ${dbHost}`);
+  }
+
+  console.log('Seeding local testing data...');
+  await ensureAcademicData();
+
+  const [isisCareer, mateCareer] = await Promise.all([
+    prisma.career.findUnique({ where: { code: 'ISIS' } }),
+    prisma.career.findUnique({ where: { code: 'MATE' } }),
+  ]);
+
+  const courses = await prisma.course.findMany({
+    where: { code: { in: requiredCourses.map((course) => course.code) } },
+  });
+  const courseByCode = new Map(courses.map((course) => [course.code, course]));
+
+  const admin = await upsertUser({
+    id: TEST_IDS.admin,
+    email: 'admin.test@calico.local',
+    name: 'Admin Testing Calico',
+    role: 'ADMIN',
+    careerId: isisCareer.id,
+    isTutorRequested: true,
+    isTutorApproved: true,
+    phoneNumber: '+57 300 000 0001',
+    phoneNumberNormalized: '+573000000001',
+  });
+
+  const student = await upsertUser({
+    id: TEST_IDS.student,
+    email: 'student.test@calico.local',
+    name: 'Estudiante Testing Calico',
+    careerId: isisCareer.id,
+    phoneNumber: '+57 300 000 0002',
+    phoneNumberNormalized: '+573000000002',
+    studentRating: 4.75,
+    studentRatingCount: 4,
+  });
+
+  const tutor = await upsertUser({
+    id: TEST_IDS.tutor,
+    email: 'tutor.test@calico.local',
+    name: 'Tutor Aprobado Testing',
+    careerId: mateCareer.id,
+    isTutorRequested: true,
+    isTutorApproved: true,
+    phoneNumber: '+57 300 000 0003',
+    phoneNumberNormalized: '+573000000003',
+  });
+
+  const pendingTutor = await upsertUser({
+    id: TEST_IDS.pendingTutor,
+    email: 'pending.tutor.test@calico.local',
+    name: 'Tutor Pendiente Testing',
+    careerId: isisCareer.id,
+    isTutorRequested: true,
+    isTutorApproved: false,
+    phoneNumber: '+57 300 000 0004',
+    phoneNumberNormalized: '+573000000004',
+  });
+
+  const suspendedTutor = await upsertUser({
+    id: TEST_IDS.suspendedTutor,
+    email: 'suspended.tutor.test@calico.local',
+    name: 'Tutor Suspendido Testing',
+    careerId: isisCareer.id,
+    isTutorRequested: true,
+    isTutorApproved: true,
+    isActive: false,
+    suspendedAt: new Date(),
+    suspendedReason: 'Cuenta de testing suspendida para probar estados admin.',
+    suspendedById: admin.id,
+    phoneNumber: '+57 300 000 0005',
+    phoneNumberNormalized: '+573000000005',
+  });
+
+  await ensureTutorProfile(admin, {
+    schoolEmail: 'admin.test@uniandes.edu.co',
+    experienceYears: 5,
+    credits: 120,
+    experienceDescription: 'Admin local con perfil de tutor para probar privilegios y vistas.',
+    bio: 'Cuenta local con rol ADMIN y tutor aprobado.',
+    llave: 'admin-testing',
+    review: 5,
+    numReview: 3,
+    numSessions: 8,
+    totalEarning: 320000,
+    nextPayment: 90000,
+  }, [
+    { courseId: courseByCode.get('ISIS1221').id, status: 'Approved', experience: 'Ha dictado programación introductoria varias veces.' },
+    { courseId: courseByCode.get('MATE1203').id, status: 'Approved', experience: 'Apoyo en cálculo para estudiantes de primer semestre.' },
+  ]);
+
+  await ensureTutorProfile(tutor, {
+    schoolEmail: 'tutor.test@uniandes.edu.co',
+    experienceYears: 3,
+    credits: 96,
+    experienceDescription: 'Tutor aprobado para probar búsqueda, perfil, disponibilidad y reservas.',
+    bio: 'Me gusta explicar con ejercicios paso a paso.',
+    llave: 'tutor-testing',
+    review: 4.8,
+    numReview: 12,
+    numSessions: 24,
+    totalEarning: 840000,
+    nextPayment: 120000,
+  }, [
+    { courseId: courseByCode.get('ISIS1221').id, status: 'Approved', experience: 'Monitor de IP durante dos semestres.' },
+    { courseId: courseByCode.get('ISIS1225').id, status: 'Approved', experience: 'Proyectos de estructuras de datos en Java y Python.' },
+    { courseId: courseByCode.get('IIND2106').id, status: 'Pending', experience: 'Solicitud pendiente para probar aprobación de materias.' },
+  ]);
+
+  await ensureTutorProfile(pendingTutor, {
+    schoolEmail: 'pending.tutor.test@uniandes.edu.co',
+    experienceYears: 1,
+    credits: 72,
+    experienceDescription: 'Aplicación pendiente para probar el flujo de aprobación admin.',
+    bio: 'Perfil pendiente de aprobación.',
+    llave: 'pending-testing',
+  }, [
+    { courseId: courseByCode.get('ISIS1221').id, status: 'Pending', experience: 'Quiere dictar programación introductoria.' },
+    { courseId: courseByCode.get('MATE1203').id, status: 'Pending', experience: 'Quiere apoyar cálculo diferencial.' },
+  ]);
+
+  await ensureTutorProfile(suspendedTutor, {
+    schoolEmail: 'suspended.tutor.test@uniandes.edu.co',
+    experienceYears: 2,
+    credits: 88,
+    experienceDescription: 'Tutor suspendido para probar estados de moderación.',
+    bio: 'Cuenta suspendida de testing.',
+    llave: 'suspended-testing',
+  }, [
+    { courseId: courseByCode.get('ISIS1225').id, status: 'Approved', experience: 'Curso aprobado antes de suspensión.' },
+  ]);
+
+  await prisma.tutorApplication.upsert({
+    where: { id: '00000000-0000-4000-8000-000000000201' },
+    update: {
+      status: 'Pending',
+      reviewedById: null,
+      reviewedAt: null,
+      rejectionReason: null,
+    },
+    create: {
+      id: '00000000-0000-4000-8000-000000000201',
+      userId: pendingTutor.id,
+      reasonsToTeach: 'Quiero ayudar a otros estudiantes y practicar mis habilidades de explicación.',
+      subjects: ['ISIS1221', 'MATE1203'],
+      contactInfo: { phone: '+573000000004', preferredChannel: 'whatsapp' },
+      status: 'Pending',
+    },
+  });
+
+  const completedSession = await prisma.session.upsert({
+    where: { id: TEST_IDS.completedSession },
+    update: {
+      status: 'Completed',
+      startTimestamp: hoursFromNow(-96),
+      endTimestamp: hoursFromNow(-95),
+    },
+    create: {
+      id: TEST_IDS.completedSession,
+      courseId: courseByCode.get('ISIS1221').id,
+      tutorId: tutor.id,
+      sessionType: 'Individual',
+      maxCapacity: 1,
+      startTimestamp: hoursFromNow(-96),
+      endTimestamp: hoursFromNow(-95),
+      status: 'Completed',
+      locationType: 'Virtual',
+      googleMeetLink: 'https://meet.google.com/testing-calico',
+      topicsToReview: 'Ciclos, listas y funciones',
+      notes: 'Sesión local de testing completada.',
+    },
+  });
+
+  const upcomingSession = await prisma.session.upsert({
+    where: { id: TEST_IDS.upcomingSession },
+    update: {
+      status: 'Accepted',
+      startTimestamp: hoursFromNow(48),
+      endTimestamp: hoursFromNow(49),
+    },
+    create: {
+      id: TEST_IDS.upcomingSession,
+      courseId: courseByCode.get('ISIS1225').id,
+      tutorId: tutor.id,
+      sessionType: 'Individual',
+      maxCapacity: 1,
+      startTimestamp: hoursFromNow(48),
+      endTimestamp: hoursFromNow(49),
+      status: 'Accepted',
+      locationType: 'Virtual',
+      googleMeetLink: 'https://meet.google.com/testing-upcoming',
+      topicsToReview: 'Árboles binarios y heaps',
+      notes: 'Sesión futura local de testing.',
+    },
+  });
+
+  const pendingSession = await prisma.session.upsert({
+    where: { id: TEST_IDS.pendingSession },
+    update: {
+      status: 'Pending',
+      startTimestamp: hoursFromNow(72),
+      endTimestamp: hoursFromNow(73),
+    },
+    create: {
+      id: TEST_IDS.pendingSession,
+      courseId: courseByCode.get('MATE1203').id,
+      tutorId: admin.id,
+      sessionType: 'Individual',
+      maxCapacity: 1,
+      startTimestamp: hoursFromNow(72),
+      endTimestamp: hoursFromNow(73),
+      status: 'Pending',
+      locationType: 'Virtual',
+      topicsToReview: 'Límites y derivadas',
+      notes: 'Sesión pendiente local de testing.',
+    },
+  });
+
+  for (const session of [completedSession, upcomingSession, pendingSession]) {
+    await prisma.sessionParticipant.upsert({
+      where: { sessionId_studentId: { sessionId: session.id, studentId: student.id } },
+      update: { participantCount: 1 },
+      create: { sessionId: session.id, studentId: student.id, participantCount: 1 },
+    });
+  }
+
+  await prisma.review.upsert({
+    where: {
+      sessionId_studentId_tutorId: {
+        sessionId: completedSession.id,
+        studentId: student.id,
+        tutorId: tutor.id,
+      },
+    },
+    update: {
+      rating: 5,
+      status: 'done',
+      comment: 'Explicación muy clara para testing.',
+      courseId: completedSession.courseId,
+    },
+    create: {
+      sessionId: completedSession.id,
+      studentId: student.id,
+      tutorId: tutor.id,
+      courseId: completedSession.courseId,
+      rating: 5,
+      status: 'done',
+      comment: 'Explicación muy clara para testing.',
+    },
+  });
+
+  await prisma.studentReview.upsert({
+    where: {
+      sessionId_tutorId_studentId: {
+        sessionId: completedSession.id,
+        tutorId: tutor.id,
+        studentId: student.id,
+      },
+    },
+    update: {
+      rating: 5,
+      status: 'done',
+      comment: 'Llegó preparado y con preguntas concretas.',
+    },
+    create: {
+      sessionId: completedSession.id,
+      tutorId: tutor.id,
+      studentId: student.id,
+      rating: 5,
+      status: 'done',
+      comment: 'Llegó preparado y con preguntas concretas.',
+    },
+  });
+
+  await prisma.payment.upsert({
+    where: { id: '00000000-0000-4000-8000-000000000301' },
+    update: {
+      status: 'paid',
+      tutorPayoutStatus: 'pending',
+      amount: 35000,
+    },
+    create: {
+      id: '00000000-0000-4000-8000-000000000301',
+      sessionId: completedSession.id,
+      studentId: student.id,
+      tutorId: tutor.id,
+      amount: 35000,
+      status: 'paid',
+      tutorPayoutStatus: 'pending',
+      wompiId: 'test_wompi_paid_001',
+    },
+  });
+
+  const notifications = [
+    {
+      id: '00000000-0000-4000-8000-000000000401',
+      userId: admin.id,
+      type: 'testing_admin',
+      message: 'Hay una aplicación de tutor pendiente para revisar.',
+      metadata: { seed: 'testing' },
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000402',
+      userId: student.id,
+      type: 'testing_session',
+      message: 'Tu sesión de testing fue aceptada.',
+      sessionId: upcomingSession.id,
+      metadata: { seed: 'testing' },
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000403',
+      userId: tutor.id,
+      type: 'testing_payout',
+      message: 'Tienes un pago de testing pendiente de liquidación.',
+      sessionId: completedSession.id,
+      metadata: { seed: 'testing' },
+    },
+  ];
+
+  for (const notification of notifications) {
+    await prisma.notification.upsert({
+      where: { id: notification.id },
+      update: notification,
+      create: notification,
+    });
+  }
+
+  console.log('');
+  console.log('Testing seed complete.');
+  console.log('');
+  console.log('Test accounts:');
+  console.log(`  Admin + approved tutor: admin.test@calico.local / ${TEST_PASSWORD}`);
+  console.log(`  Student:                student.test@calico.local / ${TEST_PASSWORD}`);
+  console.log(`  Approved tutor:         tutor.test@calico.local / ${TEST_PASSWORD}`);
+  console.log(`  Pending tutor:          pending.tutor.test@calico.local / ${TEST_PASSWORD}`);
+  console.log('');
+}
+
+main()
+  .catch((error) => {
+    console.error('Testing seed error:', error);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -3,6 +3,7 @@
  * Run: npm run db:seed
  */
 
+require('dotenv').config({ path: '.env.local' });
 require('dotenv').config();
 const { Pool } = require('pg');
 const { PrismaPg } = require('@prisma/adapter-pg');

--- a/src/app/api/calendar/auth/route.js
+++ b/src/app/api/calendar/auth/route.js
@@ -4,6 +4,7 @@
  */
 
 import { NextResponse } from 'next/server';
+import crypto from 'crypto';
 import * as calendarService from '../../../../lib/services/calendar.service';
 
 /**
@@ -12,8 +13,19 @@ import * as calendarService from '../../../../lib/services/calendar.service';
  */
 export async function GET(request) {
   try {
-    const authUrl = await calendarService.getAuthUrl();
-    return NextResponse.redirect(authUrl);
+    const csrfState = crypto.randomUUID();
+    const authUrl = await calendarService.getAuthUrl(csrfState);
+    const response = NextResponse.redirect(authUrl);
+
+    response.cookies.set('calendar_oauth_state', csrfState, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 600,
+      sameSite: 'lax',
+      path: '/api/calendar/callback',
+    });
+
+    return response;
   } catch (error) {
     console.error('Error generating auth URL:', error);
     return NextResponse.json(
@@ -25,4 +37,3 @@ export async function GET(request) {
     );
   }
 }
-

--- a/src/app/api/calendar/callback/route.js
+++ b/src/app/api/calendar/callback/route.js
@@ -10,16 +10,14 @@ import * as calendarService from '../../../../lib/services/calendar.service';
 
 const FRONTEND_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
 
-/** Clear the CSRF state cookie after use (one-time token). */
-function clearStateCookieHeader() {
-  return [
-    'calendar_oauth_state=',
-    'Max-Age=0',
-    'Path=/api/calendar/callback',
-    'HttpOnly',
-    'SameSite=Lax',
-    ...(process.env.NODE_ENV === 'production' ? ['Secure'] : []),
-  ].join('; ');
+function clearStateCookie(response) {
+  response.cookies.set('calendar_oauth_state', '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 0,
+    sameSite: 'lax',
+    path: '/api/calendar/callback',
+  });
 }
 
 export async function GET(request) {
@@ -36,7 +34,7 @@ export async function GET(request) {
     const response = NextResponse.redirect(
       `${FRONTEND_URL}/calendar-error?error=${encodeURIComponent('Invalid or missing state parameter')}`,
     );
-    response.headers.set('Set-Cookie', clearStateCookieHeader());
+    clearStateCookie(response);
     return response;
   }
 
@@ -44,14 +42,18 @@ export async function GET(request) {
     const response = NextResponse.redirect(
       `${FRONTEND_URL}/calendar-error?error=${encodeURIComponent('No authorization code provided')}`,
     );
-    response.headers.set('Set-Cookie', clearStateCookieHeader());
+    clearStateCookie(response);
     return response;
   }
 
   try {
     const tokens = await calendarService.exchangeCodeForTokens(code);
 
-    cookieStore.set('calendar_access_token', tokens.access_token, {
+    const response = NextResponse.redirect(
+      `${FRONTEND_URL}/tutor/disponibilidad?calendar_connected=true`,
+    );
+
+    response.cookies.set('calendar_access_token', tokens.access_token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       maxAge: 3600,
@@ -60,7 +62,7 @@ export async function GET(request) {
     });
 
     if (tokens.refresh_token) {
-      cookieStore.set('calendar_refresh_token', tokens.refresh_token, {
+      response.cookies.set('calendar_refresh_token', tokens.refresh_token, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         maxAge: 30 * 24 * 60 * 60,
@@ -69,10 +71,7 @@ export async function GET(request) {
       });
     }
 
-    const response = NextResponse.redirect(
-      `${FRONTEND_URL}/tutor/disponibilidad?calendar_connected=true`,
-    );
-    response.headers.set('Set-Cookie', clearStateCookieHeader());
+    clearStateCookie(response);
     return response;
   } catch (error) {
     console.error('[calendar/callback] Error exchanging code:', error);
@@ -80,7 +79,7 @@ export async function GET(request) {
     const response = NextResponse.redirect(
       `${FRONTEND_URL}/calendar-error?error=${encodeURIComponent('Error processing authorization')}`,
     );
-    response.headers.set('Set-Cookie', clearStateCookieHeader());
+    clearStateCookie(response);
     return response;
   }
 }

--- a/src/app/calendar-error/page.jsx
+++ b/src/app/calendar-error/page.jsx
@@ -1,0 +1,77 @@
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'Calico - Error conectando calendario',
+  description: 'No pudimos completar la conexion con Google Calendar.',
+};
+
+export default async function CalendarErrorPage({ searchParams }) {
+  const params = await searchParams;
+  const error =
+    typeof params?.error === 'string'
+      ? params.error
+      : 'No pudimos completar la conexion con Google Calendar.';
+
+  return (
+    <main style={styles.root}>
+      <section style={styles.panel}>
+        <p style={styles.kicker}>Google Calendar</p>
+        <h1 style={styles.title}>No pudimos conectar tu calendario</h1>
+        <p style={styles.message}>{error}</p>
+        <Link href="/tutor/disponibilidad" style={styles.action}>
+          Volver a disponibilidad
+        </Link>
+      </section>
+    </main>
+  );
+}
+
+const styles = {
+  root: {
+    minHeight: '100vh',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '24px',
+  },
+  panel: {
+    width: '100%',
+    maxWidth: '460px',
+    background: '#ffffff',
+    border: '1px solid rgba(40, 150, 86, 0.16)',
+    borderRadius: '8px',
+    boxShadow: '0 18px 50px rgba(21, 37, 31, 0.10)',
+    padding: '28px',
+  },
+  kicker: {
+    color: '#289656',
+    fontSize: '13px',
+    fontWeight: 700,
+    margin: '0 0 10px',
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: '#15251f',
+    fontSize: '24px',
+    lineHeight: 1.2,
+    margin: '0 0 12px',
+  },
+  message: {
+    color: '#5c6f66',
+    fontSize: '15px',
+    lineHeight: 1.55,
+    margin: '0 0 22px',
+  },
+  action: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '42px',
+    padding: '0 16px',
+    borderRadius: '8px',
+    background: '#289656',
+    color: '#ffffff',
+    fontWeight: 700,
+    textDecoration: 'none',
+  },
+};

--- a/src/lib/prisma.js
+++ b/src/lib/prisma.js
@@ -7,13 +7,14 @@ const globalForPrisma = globalThis;
 function createPrismaClient() {
   // Parse URL manually to avoid pg-connection-string overriding ssl config
   const url = new URL(process.env.DATABASE_URL);
+  const isLocalDatabase = ['localhost', '127.0.0.1', '::1'].includes(url.hostname);
   const pool = new Pool({
     host: url.hostname,
     port: parseInt(url.port) || 5432,
     database: url.pathname.slice(1).split('?')[0],
     user: decodeURIComponent(url.username),
     password: decodeURIComponent(url.password),
-    ssl: { rejectUnauthorized: false },
+    ssl: isLocalDatabase ? false : { rejectUnauthorized: false },
   });
   const adapter = new PrismaPg(pool);
   return new PrismaClient({ adapter });


### PR DESCRIPTION

This PR standardizes local development around a personal PostgreSQL database instead of using the shared AWS RDS database.

**Changes**
- Added `docker-compose.yml` to run a local Postgres instance.
- Added `docs/LOCAL_DATABASE.md` with setup steps for macOS, Colima, and Windows.
- Updated `README.md` to point developers to the local database guide.
- Added `prisma/seed-testing.js` with local-only fake users, tutors, sessions, reviews, payments, and notifications.
- Added `pnpm db:seed:test`.
- Updated Prisma/env loading to support `.env.local`.
- Updated Prisma PG SSL config so local DB connections use `ssl: false`, while remote DB connections keep SSL enabled.

**Testing Accounts**
```txt
admin.test@calico.local         / CalicoTest123!
student.test@calico.local       / CalicoTest123!
tutor.test@calico.local         / CalicoTest123!
pending.tutor.test@calico.local / CalicoTest123!
```

**How To Test**
```bash
docker-compose up -d postgres
pnpm db:push
pnpm db:seed
pnpm db:seed:test
pnpm dev
```

Then log in with:

```txt
admin.test@calico.local / CalicoTest123!
```

**Notes**
The testing seed refuses to run unless `DATABASE_URL` points to localhost, to avoid seeding fake data into AWS/RDS by accident.