### PR TITLE
Corrige el flujo de subida de archivos en la reserva (bloqueo por CSP, botón atascado) + SSL del seed local

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,8 +15,12 @@ const cspDirectives = [
   "font-src 'self' https://fonts.gstatic.com",
   // data: for base64 avatars; blob: for object URLs; *.amazonaws.com for S3
   "img-src 'self' data: blob: https://*.amazonaws.com https://lh3.googleusercontent.com https://storage.googleapis.com",
-  // API and OAuth endpoints the browser needs to reach directly
-  "connect-src 'self' https://api.wompi.co https://production.wompi.co https://sandbox.wompi.co https://accounts.google.com",
+  // API and OAuth endpoints the browser needs to reach directly.
+  // *.amazonaws.com is required for the browser's direct PUT to S3 presigned
+  // URLs (session attachment uploads) — without it the browser blocks the
+  // request at the CSP layer before it leaves the machine, which XHR reports
+  // to JS as a generic network error indistinguishable from a real outage.
+  "connect-src 'self' https://api.wompi.co https://production.wompi.co https://sandbox.wompi.co https://accounts.google.com https://*.amazonaws.com",
   // Wompi renders its checkout in an iframe
   "frame-src https://checkout.wompi.co",
   "frame-ancestors 'none'",

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -17,7 +17,9 @@ function createClient() {
     database: url.pathname.slice(1).split('?')[0],
     user: decodeURIComponent(url.username),
     password: decodeURIComponent(url.password),
-    ssl: { rejectUnauthorized: false },
+    ssl: url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+      ? false
+      : { rejectUnauthorized: false },
   });
   return new PrismaClient({ adapter: new PrismaPg(pool) });
 }

--- a/src/__tests__/components/__snapshots__/TutoringHistoryCard.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/TutoringHistoryCard.test.jsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_past_completed_session_with_calendar_link 1`] = `
 <DocumentFragment>
@@ -15,6 +15,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
           class="tutor-avatar"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-user"
             fill="none"
             height="24"
@@ -56,6 +57,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
         style="background-color: rgb(230, 249, 237); color: rgb(15, 81, 50); border: 1px solid rgb(188, 229, 208);"
       >
         <svg
+          aria-hidden="true"
           class="lucide lucide-credit-card"
           fill="none"
           height="14"
@@ -103,6 +105,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
           class="detail-item"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-calendar"
             fill="none"
             height="16"
@@ -141,6 +144,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
           class="detail-item"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-dollar-sign"
             fill="none"
             height="16"
@@ -190,6 +194,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
           title="Ver detalles completos del evento"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-external-link"
             fill="none"
             height="16"
@@ -234,6 +239,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
           class="tutor-avatar"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-user"
             fill="none"
             height="24"
@@ -275,6 +281,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
         style="background-color: rgb(230, 249, 237); color: rgb(15, 81, 50); border: 1px solid rgb(188, 229, 208);"
       >
         <svg
+          aria-hidden="true"
           class="lucide lucide-credit-card"
           fill="none"
           height="14"
@@ -322,6 +329,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
           class="detail-item"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-calendar"
             fill="none"
             height="16"
@@ -360,6 +368,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
           class="detail-item"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-dollar-sign"
             fill="none"
             height="16"
@@ -409,6 +418,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_pa
           title="Calificar al tutor"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-star"
             fill="none"
             height="16"
@@ -447,6 +457,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_up
           class="tutor-avatar"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-user"
             fill="none"
             height="24"
@@ -488,6 +499,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_up
         style="background-color: rgb(255, 244, 224); color: rgb(122, 75, 0); border: 1px solid rgb(255, 214, 153);"
       >
         <svg
+          aria-hidden="true"
           class="lucide lucide-credit-card"
           fill="none"
           height="14"
@@ -535,6 +547,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_up
           class="detail-item"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-calendar"
             fill="none"
             height="16"
@@ -573,6 +586,7 @@ exports[`TutoringHistoryCard — DOM snapshots test_should_match_snapshot_for_up
           class="detail-item"
         >
           <svg
+            aria-hidden="true"
             class="lucide lucide-dollar-sign"
             fill="none"
             height="16"

--- a/src/app/components/FileUploader/FileUploader.jsx
+++ b/src/app/components/FileUploader/FileUploader.jsx
@@ -8,8 +8,7 @@
  *   maxFiles      — Max files allowed (default 5, for display only)
  *   disabled      — Disable all interactions
  *   onRetry       — (optional) called with fileId when the user clicks retry;
- *                   if omitted, the retry button is hidden. Retry only makes
- *                   sense once a sessionId is known (after payment).
+ *                   if omitted, the retry button is hidden.
  */
 
 import { useCallback, useRef, useState } from 'react';

--- a/src/app/home/agendar/BookingForm.jsx
+++ b/src/app/home/agendar/BookingForm.jsx
@@ -9,14 +9,62 @@ import FileUploader from '../../components/FileUploader/FileUploader';
 const TOPICS_MAX_LENGTH = 2000;
 
 /**
+ * Open the Wompi widget and report back what happened.
+ *
+ * Wompi's WidgetCheckout only invokes checkout.open()'s callback once a
+ * transaction is attempted/completed — it has no documented onClose hook, so
+ * a user who dismisses the widget's own close (X) button without paying never
+ * fires that callback, and any state set to "processing" before open() is
+ * left stuck forever. To recover from that, watch the DOM for the iframe the
+ * widget injects and treat its removal (with no transaction reported yet) as
+ * a cancelled attempt.
+ *
+ * @param {object} checkout - an instance returned by `new window.WidgetCheckout(...)`
+ * @param {(result: object|null) => void} onResult - called with Wompi's result
+ *   object on completion, or `null` if the widget was closed without one.
+ */
+function openWompiCheckout(checkout, onResult) {
+    let settled = false;
+    const iframesBefore = new Set(document.querySelectorAll('iframe'));
+    let widgetFrame = null;
+    let closeObserver = null;
+
+    const openObserver = new MutationObserver(() => {
+        if (widgetFrame) return;
+        widgetFrame = Array.from(document.querySelectorAll('iframe')).find(
+            (frame) => !iframesBefore.has(frame),
+        );
+        if (!widgetFrame) return;
+
+        openObserver.disconnect();
+        closeObserver = new MutationObserver(() => {
+            if (settled || document.body.contains(widgetFrame)) return;
+            closeObserver.disconnect();
+            onResult(null);
+        });
+        closeObserver.observe(document.body, { childList: true, subtree: true });
+    });
+    openObserver.observe(document.body, { childList: true, subtree: true });
+
+    checkout.open((result) => {
+        settled = true;
+        openObserver.disconnect();
+        closeObserver?.disconnect();
+        onResult(result);
+    });
+}
+
+/**
  * Right column on desktop, bottom stack on mobile. Owns all transactional
  * state: topics text, file uploads, Wompi widget invocation, server-side
- * payment confirmation. The integrations (useFileUpload → S3 presigned URLs,
- * PaymentService.createWompiPayment, /api/payments/confirm-payment) are a
- * verbatim port of SessionConfirmationModal so behavior is identical.
+ * payment confirmation.
  *
  * Validation rules:
  *   - "Pagar" is disabled until topics is non-empty (required field).
+ *   - Files upload as soon as they're added (see the auto-upload effect
+ *     below); "Pagar" stays disabled/busy while any upload is in flight and
+ *     blocked outright if one errored, so a failed upload is always resolved
+ *     (removed or retried) before payment — never silently dropped.
  *   - When topics is filled but no files attached, clicking "Pagar" first
  *     opens a soft confirmation asking if they want to attach material.
  */
@@ -44,16 +92,33 @@ export default function BookingForm({ session, onSuccess }) {
 
     const trimmedTopics = topicsToReview.trim();
     const hasFiles = fileUpload.files.length > 0;
+    const hasFileErrors = fileUpload.files.some((f) => f.status === 'error');
+    // Includes 'pending' (not just 'uploading') so the CTA stays blocked during
+    // the brief window between a file landing in the queue and the auto-upload
+    // effect below picking it up — otherwise payment could start with a file
+    // that never actually got sent to S3.
+    const hasUnsettledFiles = fileUpload.files.some(
+        (f) => f.status === 'pending' || f.status === 'uploading',
+    );
     const emailOk = isValidEmail(session.studentEmail);
     const isFormValid = trimmedTopics.length > 0 && emailOk;
-    const isCTABusy = isPaymentInitiated || fileUpload.isUploading;
-    const isCTADisabled = isCTABusy || !isFormValid;
+    const isCTABusy = isPaymentInitiated || hasUnsettledFiles;
+    const isCTADisabled = isCTABusy || !isFormValid || hasFileErrors;
 
     const ctaLabel = useMemo(() => {
         if (isPaymentInitiated) return 'Procesando…';
-        if (fileUpload.isUploading) return 'Subiendo archivos…';
+        if (hasUnsettledFiles) return 'Subiendo archivos…';
         return 'Pagar con Wompi';
-    }, [isPaymentInitiated, fileUpload.isUploading]);
+    }, [isPaymentInitiated, hasUnsettledFiles]);
+
+    // Upload files to S3 as soon as they're added to the queue, instead of
+    // deferring it to the "Pagar" click. This way upload errors surface (and
+    // can be retried or removed) before the user ever reaches payment.
+    useEffect(() => {
+        if (fileUpload.files.some((f) => f.status === 'pending')) {
+            fileUpload.uploadFiles();
+        }
+    }, [fileUpload.files, fileUpload.uploadFiles]);
 
     /** Click handler on the main CTA: enforces validation, then either opens
      *  the no-files dialog or proceeds straight to payment. */
@@ -110,11 +175,12 @@ export default function BookingForm({ session, onSuccess }) {
             }
 
             const amountInCents = (session.price || 25000) * 100;
-            // Upload any pending/failed files and use the RETURNED metadata.
-            // (Reading fileUpload.uploadedFiles here is a stale-closure trap: it
-            //  reflects the render before the upload finished, so the files the
-            //  user just added would silently be dropped from the payment.)
-            const successAttachments = await fileUpload.uploadFiles();
+            // Files are uploaded as soon as they're added (see the effect above),
+            // and the CTA is disabled while any upload is in flight or errored —
+            // so by the time we get here, fileUpload.uploadedFiles already holds
+            // the final, settled list. No stale-closure risk: nothing is still
+            // uploading at click time.
+            const successAttachments = fileUpload.uploadedFiles;
 
             const paymentInitData = {
                 tutorId: session.tutorId,
@@ -169,7 +235,15 @@ export default function BookingForm({ session, onSuccess }) {
                 customerData: customerDataForWidget,
             });
 
-            checkout.open((result) => {
+            openWompiCheckout(checkout, (result) => {
+                if (!result) {
+                    // The widget was closed without a transaction result (Wompi's
+                    // WidgetCheckout has no onClose callback — see openWompiCheckout).
+                    // Unlock the form so the user can edit and retry.
+                    setError('Cerraste la ventana de pago antes de terminar. Puedes intentarlo de nuevo cuando quieras.');
+                    setIsPaymentInitiated(false);
+                    return;
+                }
                 const transaction = result.transaction;
                 if (transaction.status === 'APPROVED') {
                     setPaymentApprovedMsg('Pago exitoso');
@@ -177,7 +251,8 @@ export default function BookingForm({ session, onSuccess }) {
                 } else if (transaction.status === 'DECLINED') {
                     setError('Pago rechazado (fondos insuficientes u otro motivo).');
                     setIsPaymentInitiated(false);
-                } else if (transaction.status === 'ERROR') {
+                } else {
+                    // ERROR, PENDING, or any other/unexpected status.
                     setError('Error procesando el pago, intenta nuevamente.');
                     setIsPaymentInitiated(false);
                 }
@@ -282,7 +357,12 @@ export default function BookingForm({ session, onSuccess }) {
                 <p className="text-xs text-gray-500 mb-2">
                     Sube talleres, tareas o material que quieras revisar en la tutoría.
                 </p>
-                <FileUploader fileUpload={fileUpload} maxFiles={5} disabled={isPaymentInitiated} />
+                <FileUploader
+                    fileUpload={fileUpload}
+                    maxFiles={5}
+                    disabled={isPaymentInitiated}
+                    onRetry={fileUpload.retryFile}
+                />
             </div>
 
             {/* Wompi info card */}
@@ -317,6 +397,11 @@ export default function BookingForm({ session, onSuccess }) {
             {!trimmedTopics && !error && (
                 <p className="text-xs text-gray-500 italic text-center">
                     Completa el campo &quot;¿Qué temas quieres repasar?&quot; para poder continuar.
+                </p>
+            )}
+            {trimmedTopics && hasFileErrors && !error && (
+                <p className="text-xs text-red-500 italic text-center">
+                    Elimina o reintenta el archivo que falló antes de continuar con el pago.
                 </p>
             )}
 


### PR DESCRIPTION
Problema --------
1. Subir un archivo de apoyo durante la reserva siempre fallaba con "Error de red al subir el archivo", incluso con buena conexión, y la tutoría igual quedaba reservada SIN el archivo adjunto. Causa raíz: el Content-Security-Policy de la app permitía https://*.amazonaws.com en `img-src` (para mostrar archivos ya subidos) pero nunca lo agregaba a `connect-src`, así que el navegador bloqueaba el PUT directo a la URL presignada de S3 antes de que saliera de la máquina. XHR reporta un bloqueo de CSP igual que una falla de red real, por eso parecía un problema de conexión. Lo verifiqué de punta a punta con un navegador real (Playwright): el PUT empezó a responder 200 apenas agregué `https://*.amazonaws.com` a `connect-src`.

2. La subida solo se disparaba al hacer clic en "Pagar" (después de que isPaymentInitiated ya era true), así que un error de subida no se detectaba hasta el momento del pago, y un error por archivo no impedía que la reserva se completara sin ese archivo.

3. Los botones de eliminar/reintentar archivo y el botón "Pagar" quedaban atascados en "Procesando..." para siempre si el usuario cerraba el pop-up de pago de Wompi sin completar el pago. El WidgetCheckout de Wompi no tiene un callback onClose documentado, así que isPaymentInitiated nunca se reseteaba en ese caso.

4. `pnpm db:seed` fallaba localmente con un error de TLS ("server does not support SSL connections") porque prisma/seed.js forzaba `ssl: { rejectUnauthorized: false }` en cualquier entorno, a diferencia de src/lib/prisma.js y prisma/seed-testing.js, que correctamente desactivan SSL para localhost.

Cambios -------
- next.config.mjs: agrega https://*.amazonaws.com a la directiva `connect-src` del CSP para que el navegador permita la subida directa a S3.
- src/app/home/agendar/BookingForm.jsx:
  - Sube los archivos apenas se agregan (nuevo efecto), en vez de esperar al clic en "Pagar", para que los errores aparezcan de inmediato.
  - Bloquea "Pagar" mientras haya algún archivo pendiente/subiendo/con error (hasFileErrors / hasUnsettledFiles), para que una reserva ya no pueda completarse sin un archivo que el usuario sí intentó adjuntar.
  - Conecta el reintento (fileUpload.retryFile) para poder corregir una subida fallida antes de pagar.
  - Agrega openWompiCheckout(): observa el DOM en busca del iframe que inyecta Wompi y trata su eliminación sin resultado de transacción como un intento cancelado, reseteando isPaymentInitiated para desbloquear el formulario.
  - Trata cualquier estado de transacción distinto de APROBADO/RECHAZADO (ej. PENDING) como caso de reseteo en vez de dejar el botón atascado.
- src/app/components/FileUploader/FileUploader.jsx: corrige el comentario de onRetry (ya no depende de "después del pago").
- prisma/seed.js: solo fuerza SSL para hosts no locales, igual que prisma/seed-testing.js y src/lib/prisma.js, para que `pnpm db:seed` funcione contra el Postgres local.
- src/__tests__/components/__snapshots__/TutoringHistoryCard.test.jsx.snap: actualiza un snapshot desactualizado para reflejar los atributos aria-hidden que ya había introducido el bump de lucide-react (deuda preexistente, sin relación con este fix).

